### PR TITLE
invokable API Endpoint URLs are available now

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,9 +223,9 @@ class ServerlessPlugin {
         });
 
         // Compare apples-to-apples (configured-to-deployed) and record deployment status
-        if (this.cache.deployedAPIs.some(deployedAPI => deployedAPI.apiClob === apiDefClob)) {
-          const apiStatus = this.cache.deployedAPIs.find(deployedAPI => deployedAPI.apiClob === apiDefClob).apiStatus;
-          const apiId = this.cache.deployedAPIs.find(deployedAPI => deployedAPI.apiClob === apiDefClob).apiId;
+        if (this.cache.deployedAPIs.some(deployedAPI => deployedAPI.apiClob == apiDefClob)) {
+          const apiStatus = this.cache.deployedAPIs.find(deployedAPI => deployedAPI.apiClob == apiDefClob).apiStatus;
+          const apiId = this.cache.deployedAPIs.find(deployedAPI => deployedAPI.apiClob == apiDefClob).apiId;
           var invokableAPIURL = null;
 
           // Check for PUBLISHED state, if PUBLISHED then retrieve Invokable API URL
@@ -247,6 +247,7 @@ class ServerlessPlugin {
             apiVersion: apiDef.version,
             apiContext: apiDef.rootContext,
             apiStatus: apiStatus,
+            apiId, apiId,
             invokableAPIURL: invokableAPIURL + " 🚀",
           });
         }
@@ -256,6 +257,7 @@ class ServerlessPlugin {
             apiVersion: apiDef.version,
             apiContext: apiDef.rootContext,
             apiStatus: "TO BE CREATED",
+            apiId: null,
             invokableAPIURL: "TO BE CREATED",
           })
         }

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -349,7 +349,7 @@ async function uploadCert(url, accessToken, certAlias, certFile, backendUrl) {
 // Updates API definition
 async function updateAPIDef(url, user, accessToken, gatewayEnv, apiDef, apiId) {
     try {
-        url = "url + "/"" + apiId;
+        url = url + "/" + apiId;
         var data = constructAPIDef(user, gatewayEnv, apiDef, apiId);
         var config = {
             headers: {

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -279,6 +279,37 @@ async function publishAPIDef(url, accessToken, apiId) {
     }  
 };
 
+
+// Retrieves invokable API endpoint
+async function listInvokableAPIUrl(url, accessToken, apiId) {
+    try {
+        url = url + "/" + apiId;
+        var config = {
+            headers: {
+                'Authorization': 'Bearer ' + accessToken
+            },
+            httpsAgent: new https.Agent({
+                rejectUnauthorized: false
+            })
+        };
+
+        return new Promise((resolve, reject) => {
+            axios.get(url, config)
+                .then((res) => {
+                    resolve(res.data);
+                })
+                .catch((err) => {
+                    utils.renderError(err);
+                    reject(err);
+                });
+        });
+    }
+    catch (err) {
+        utils.renderError(err);
+    }  
+};
+
+
 // Uploads backend certificate
 async function uploadCert(url, accessToken, certAlias, certFile, backendUrl) {
     try {
@@ -318,7 +349,7 @@ async function uploadCert(url, accessToken, certAlias, certFile, backendUrl) {
 // Updates API definition
 async function updateAPIDef(url, user, accessToken, gatewayEnv, apiDef, apiId) {
     try {
-        url = url + "/" + apiId;
+        url = "url + "/"" + apiId;
         var data = constructAPIDef(user, gatewayEnv, apiDef, apiId);
         var config = {
             headers: {
@@ -419,5 +450,6 @@ module.exports = {
     uploadCert,
     updateAPIDef,
     removeAPIDef,
-    removeCert
+    removeCert,
+    listInvokableAPIUrl,
 };


### PR DESCRIPTION
Task: https://github.com/ramgrandhi/serverless-wso2-apim/projects/1#card-42839186

Comment: As a result of `sls list apidefs` command, it will now retrieve invokable API URLs and present them.
