### PR TITLE
Support added for AWS ACM ARN for certificates, Simplified commands to deploy/remove/list API refs and more..

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Serverless Framework plugin to manage APIs in [WSO2 API Manager](https://wso2.co
 * [WSO2 API Manager 2.6.0](https://docs.wso2.com/display/AM260/)
 
 ## Features
-* Create or Update your API definitions (including backend certificates) seamlessly with one command - `sls deploy apidefs`.  
-* Manage your API definitions via `sls list apidefs` and `sls remove apidefs`.  
-* Management your backend certificates via `sls list certs` and `sls remove certs`.  
-* Automatically publish / re-publish APIs to WSO2 API Store when changes occur to your API definitions.  
+* Create or Update your API definitions (including backend certificates) seamlessly with one command - `sls deploy`.  
+* Manage your API definitions via `sls info` and `sls remove`.  
+* Automatically uploads backend certificates (including CAs) to enable HTTP/S based connectivity with backends.
+* Backend certificates can be supplied using `file://` (relative to where `serverless.yml` file is located) or `arn:aws:acm:..` (AWS ACM Certificate ARN).  
+* Automatically publish / re-publish APIs to WSO2 API Store on every deploy.
 
 ---
 
@@ -51,55 +52,51 @@ or
 - Add one or more API definitions to your Serverless configuration, as below.
 
   ```yml
-  apidefs:
-    - myAwesomeAPI: # Identifier of your API definition
-      name: 'MyAwesomeAPI'  # Name of API that shows up in WSO2 API Console (CANNOT BE UPDATED LATER)
-      description: 'My Awesome API'
-      rootContext: '/myawesomeapi'  # Runtime context of API which will be appended to the base URL exposed by WSO2 API Gateway. Must be unique across the Gateway Environment. (CANNOT BE UPDATED LATER)
-      version: 'v1' # Version, which also forms a part of the API URL ultimately (CANNOT BE UPDATED LATER)
-      visibility: 'PUBLIC'  # Accessible from Public Internet, Visible to everyone
-      backend: 
-        http: # HTTP-based Backends
-          baseUrl: 'https://backend:port/123'  # Backend RESTful base URL
-          publicCertChain: './certs/backend.cer'  # Optional, public certificate chain in PEM base64 format
-      maxTps: 100 # Throttling, Transactions per second
-      tags:
-        - my-awesome-api
-        - awesomeness
-      swaggerSpec:  # Swagger specification in YML, currently supports 2.0
-        swagger: '2.0'
-        ...
-        info:
-          ...
-        paths:
-          ...
+  custom:
+    wso2apim:
+      apidefs:
+        - myAwesomeAPI: # Identifier of your API definition
+          name: 'MyAwesomeAPI'  # (CANNOT BE UPDATED LATER) Name of API that shows up in WSO2 API Console
+          version: 'v1' # (CANNOT BE UPDATED LATER) Version, which also forms a part of the API URL ultimately 
+          rootContext: '/myawesomeapi'  # (CANNOT BE UPDATED LATER) Runtime context of API which will be exposed by WSO2 API Gateway. Must be unique across the Gateway Environment.
+          description: 'My Awesome API'
+          visibility: 'PUBLIC'  # Accessible from Public Internet, Visible to everyone
+          backend: 
+            http: # HTTP-based Backends
+              baseUrl: 'https://backend:port/123'  # Backend RESTful base URL
+              certChain: 'file://certs/backend.cer'  # Optional, certificate chain in PEM (base64) format. 
+                                                     # Alternatively, you can also supply AWS ACM Certificate ARN (e.g. arn:aws:acm:...) too.
+          maxTps: 100 # Throttling, Transactions per second
+          tags:
+            - my-awesome-api
+            - awesomeness
+          swaggerSpec:  # Swagger specification in YML, currently supports 2.0
+            swagger: '2.0'
+            ...
+            info:
+              ...
+            paths:
+              ...
   ```
 
-- Run `sls deploy apidefs` to create-and-publish (or) update-and-republish API definitions (and associated backend certificates, if mentioned) in WSO2 API Manager.
+- Run `sls deploy` to create-and-publish (or) update-and-republish API definitions (and associated backend certificates, if supplied) in WSO2 API Manager.
 
-- Run `sls list apidefs` to view the status of API deployment on WSO2 API Manager.
+- Run `sls info` to view the status of API deployment on WSO2 API Manager.
 
-- Run `sls list certs` to view the status of backend certificate availability.
-
-- Run `sls remove apidefs` to delete API definitions when there are no active subscriptions made to those APIs.
-
-- Run `sls remove certs` to delete backend certificates when they are found.
+- Run `sls remove` to delete API definitions (and associated backend certificates, if exists) when there are no active subscriptions exist on those APIs.
 
 
 - ** COMING SOON **   
-Run `sls remove apidefs --force` (** USE WITH CAUTION **) to forcefully delete API definitions despite any active subscriptions. It will retire, deprecate and delete API definitions if they cannot be deleted normally.
+Run `sls remove --force` (** USE WITH CAUTION **) to forcefully delete API definitions (and associated backend certificates) despite any active subscriptions that may exist. API definitions will be retired and deprecated before removing it completely from WSO2 API Manager.
 
 
 ## Limitations and Backlog items
 * Limited to creation of RESTful APIs using Swagger 2.0 on WSO2 API Manager. 
 * Limited to WSO2 API Manager 2.6.0 which uses v0.14 as management API version. 
-* Does not support managing APIs which are already created in another manner without using this Plugin.
-* Does not work with Websocket-style APIs.  
-* Does not support publishing API definitions to multiple Gateway environments.  
-* Does not support CORS configuration.
+* For a full list of backlog items, refer to [what's coming up?](https://github.com/ramgrandhi/serverless-wso2-apim/projects/1)
 
 ## Need Help?
-* Raise an issue [here](https://github.com/ramgrandhi/serverless-wso2-apim/issues/new)
+* Join us on Slack [here](https://join.slack.com/t/serverless-wso2-apim/shared_invite/zt-gidayta8-3kEztQh8QzA2lO4fBGv3IA)
 
 ## License
 [MIT](https://github.com/99xt/serverless-dynamodb-local/blob/v1/LICENSE)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "serverless-wso2-apim",
   "version": "0.1.1",
   "description": "Serverless Framework plugin for WSO2 API Manager",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "release:alpha": "release pre alpha",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "https": "^1.0.0",
     "qs": "^6.9.4",
     "release": "^6.3.0",
-    "serverless": "^1.75.1"
-  }
+    "serverless": "^1.75.1",
+    "split-ca": "^1.0.1"
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-wso2-apim",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Serverless Framework plugin for WSO2 API Manager",
   "main": "src/index.js",
   "scripts": {

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -311,10 +311,10 @@ async function listInvokableAPIUrl(url, accessToken, apiId) {
 
 
 // Uploads backend certificate
-async function uploadCert(url, accessToken, certAlias, certFile, backendUrl) {
+async function uploadCert(url, accessToken, certAlias, cert, backendUrl) {
     try {
         var data = new FormData();
-        data.append('certificate', fs.createReadStream(certFile));
+        data.append('certificate', fs.createReadStream(cert))
         data.append('alias', certAlias);
         data.append('endpoint', backendUrl);
         var config = {

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -51,8 +51,9 @@ async function registerClient(url, user, pass) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
+
 
 // Generate a new token
 async function generateToken(url, user, pass, clientId, clientSecret, scope) {
@@ -90,7 +91,7 @@ async function generateToken(url, user, pass, clientId, clientSecret, scope) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
 async function isAPIDeployed(url, accessToken, apiName, apiVersion, apiContext) {
@@ -119,7 +120,7 @@ async function isAPIDeployed(url, accessToken, apiName, apiVersion, apiContext) 
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
 async function isCertUploaded(url, accessToken, certAlias) {
@@ -150,63 +151,62 @@ async function isCertUploaded(url, accessToken, certAlias) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
-    
+
 
 
 function constructAPIDef(user, gatewayEnv, apiDef, apiId) {
     try {
-        var wso2ApiDefinition = {};
-
-        if (apiId !== undefined)
-            wso2ApiDefinition.id = apiId;
-
-        wso2ApiDefinition = {
-            'name': apiDef.name,
-            'description': apiDef.description,
-            'context': apiDef.rootContext,
-            'version': apiDef.version,
-            'provider': user,
-            'apiDefinition': JSON.stringify(apiDef.swaggerSpec),
-            'status': 'CREATED',
-            'isDefaultVersion': false,
-            'type': 'HTTP',
-            'transport': ['https'],
-            'tags': [...apiDef.tags, "serverless-wso2-apim"],
-            'tiers': ['Unlimited'],
-            'maxTps': {
-                'sandbox': apiDef.maxTps,
-                'production': apiDef.maxTps
+        const wso2ApiDefinition = {
+            name: apiDef.name,
+            description: apiDef.description,
+            context: apiDef.rootContext,
+            version: apiDef.version,
+            provider: user,
+            apiDefinition: JSON.stringify(apiDef.swaggerSpec),
+            status: 'CREATED',
+            isDefaultVersion: false,
+            type: 'HTTP',
+            transport: ['https'],
+            tags: [...apiDef.tags, "serverless-wso2-apim"],
+            tiers: ['Unlimited'],
+            maxTps: {
+                sandbox: apiDef.maxTps,
+                production: apiDef.maxTps
             },
-            'visibility': apiDef.visibility,
-            'endpointConfig': JSON.stringify({
-                'production_endpoints': {
-                    'url': apiDef.backend.http.baseUrl,
-                    'config': null
+            visibility: apiDef.visibility,
+            endpointConfig: JSON.stringify({
+                production_endpoints: {
+                    url: apiDef.backend.http.baseUrl,
+                    config: null
                 },
-                'sandbox_endpoints': {
-                    'url': apiDef.backend.http.baseUrl,
-                    'config': null
+                sandbox_endpoints: {
+                    url: apiDef.backend.http.baseUrl,
+                    config: null
                 },
-                'endpoint_type': 'http'
+                endpoint_type: 'http'
             }),
-            'endpointSecurity': null,
-            'gatewayEnvironments': gatewayEnv,
-            'subscriptionAvailability': 'current_tenant',
-            'subscriptionAvailableTenants': [],
-            'businessInformation': {
-                'businessOwnerEmail': apiDef.swaggerSpec.info.contact.email,
-                'technicalOwnerEmail': apiDef.swaggerSpec.info.contact.email,
-                'technicalOwner': apiDef.swaggerSpec.info.contact.name,
-                'businessOwner': apiDef.swaggerSpec.info.contact.name
+            endpointSecurity: null,
+            gatewayEnvironments: gatewayEnv,
+            subscriptionAvailability: 'current_tenant',
+            subscriptionAvailableTenants: [],
+            businessInformation: {
+                businessOwnerEmail: apiDef.swaggerSpec.info.contact.email,
+                technicalOwnerEmail: apiDef.swaggerSpec.info.contact.email,
+                technicalOwner: apiDef.swaggerSpec.info.contact.name,
+                businessOwner: apiDef.swaggerSpec.info.contact.name
             }
         };
+
+        if (apiId)
+            wso2ApiDefinition.id = apiId;
+
         return wso2ApiDefinition;
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
 // Creates API definition
@@ -242,7 +242,7 @@ async function createAPIDef(url, user, accessToken, gatewayEnv, apiDef) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
 // Publishes API definition
@@ -275,7 +275,7 @@ async function publishAPIDef(url, accessToken, apiId) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
 
@@ -305,7 +305,7 @@ async function listInvokableAPIUrl(url, accessToken, apiId) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
 
@@ -342,7 +342,7 @@ async function uploadCert(url, accessToken, certAlias, cert, backendUrl) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
 // Updates API definition
@@ -373,7 +373,7 @@ async function updateAPIDef(url, user, accessToken, gatewayEnv, apiDef, apiId) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
 // Removes API definition (if possible)
@@ -402,10 +402,10 @@ async function removeAPIDef(url, accessToken, apiId) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
-    
+
 // Removes backend certificate
 async function removeCert(url, accessToken, certAlias) {
     try {
@@ -435,7 +435,7 @@ async function removeCert(url, accessToken, certAlias) {
     }
     catch (err) {
         utils.renderError(err);
-    }  
+    }
 };
 
 

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -15,7 +15,6 @@ const qs = require('qs');
 const FormData = require('form-data');
 const path = require('path');
 const fs = require('fs');
-const swagger = require('swagger-client');
 const utils = require('../utils/utils');
 
 // Register a new client

--- a/src/index.js
+++ b/src/index.js
@@ -493,7 +493,6 @@ class Serverless_WSO2_APIM {
         }
         catch (err) {
           this.serverless.cli.log(pluginNameSuffix + "Deleting " + api.apiId + ".. NOT OK, proceeding further.");
-          utils.renderError(err);
         }
       };
       this.serverless.cli.log(pluginNameSuffix + "Deleting API definitions.. OK");
@@ -528,6 +527,7 @@ class Serverless_WSO2_APIM {
               this.cache.accessToken,
               certAliasPrefix + "___" + j
             );
+            console.log("removed " + certAliasPrefix + "___" + j);
           }
         }
         catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ class Serverless_WSO2_APIM {
         "apim:api_create apim:api_publish apim:api_view apim:subscribe apim:tier_view apim:tier_manage apim:subscription_view apim:subscription_block",
       );
       this.cache.accessToken = data.accessToken;
-      this.serverless.cli.log(pluginNameSuffix + "Generating temporary token.. OK" + " " + this.cache.accessToken);
+      this.serverless.cli.log(pluginNameSuffix + "Generating temporary token.. OK");
     }
     catch (err) {
       this.serverless.cli.log(pluginNameSuffix + "Generating temporary token.. NOT OK");

--- a/src/index.js
+++ b/src/index.js
@@ -528,7 +528,6 @@ class Serverless_WSO2_APIM {
               this.cache.accessToken,
               certAliasPrefix + "___" + j
             );
-            console.log("removed " + certAliasPrefix + "___" + j);
           }
         }
         catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,21 @@
 'use strict';
-const wso2apim = require("./src/2.6.0/wso2apim");
-const utils = require('./src/utils/utils');
+const wso2apim = require("./2.6.0/wso2apim");
+const utils = require('./utils/utils');
+const fs = require('fs');
+const pluginNameSuffix = '[serverless-wso2-apim] ';
 
 console.log.apply(null);
 
-class ServerlessPlugin {
+class Serverless_WSO2_APIM {
 
   constructor(serverless, options) {
+    this.cache = {}
+
     this.serverless = serverless;
     this.options = options;
   
     this.wso2APIM = serverless.service.custom.wso2apim;
-    this.apiDefs = serverless.pluginManager.serverlessConfigFile.apidefs;
-    this.cache = {}
+    this.apiDefs = this.wso2APIM.apidefs;
     this.cmd = this.serverless.pluginManager.cliCommands.join('|');
 
     //Retrieve tenantSuffix in case of multi-tenant setup
@@ -20,127 +23,95 @@ class ServerlessPlugin {
       this.cache.tenantSuffix = this.wso2APIM.user.split("@")[1];
     }
 
-    this.commands = {
-      deploy: {
-        commands: {
-          apidefs: {
-            usage: 'Creates or Updates API definitions in WSO2 API Manager.',
-            lifecycleEvents: [
-              'registerClient',
-              'generateToken',
-              'uploadCerts',
-              'createOrUpdateAPIDefs',
-            ],
-          }
-        },
-      },
-      list: {
-        commands: {
-          apidefs: {
-            usage: 'Lists the deployment status of API definitions in WSO2 API Manager.',
-            lifecycleEvents: [
-              'registerClient',
-              'generateToken',
-              'listAPIDefs',
-            ]
-          },
-          certs: {
-            usage: 'Lists the backend certificates associated with API definitions in WSO2 API Manager.',
-            lifecycleEvents: [
-              'registerClient',
-              'generateToken',
-              'listCerts',
-            ]
-          }
-        }
-      },
-      remove: {
-        commands: {
-          apidefs: {
-            usage: 'Deletes API definitions in WSO2 API Manager.',
-            lifecycleEvents: [
-              'registerClient',
-              'generateToken',
-              'removeAPIDefs',
-            ],
-          },
-          certs: {
-            usage: 'Deletes backend certificates associated with API definitions in WSO2 API Manager.',
-            lifecycleEvents: [
-              'registerClient',
-              'generateToken',
-              'removeCerts',
-            ],
-          }
-        },
-      },
-    };
-
-
     this.hooks = {
-      'deploy:apidefs:registerClient': this.registerClient.bind(this),
-      'deploy:apidefs:generateToken': this.generateToken.bind(this),
-      'deploy:apidefs:uploadCerts': this.uploadCerts.bind(this),
-      'deploy:apidefs:createOrUpdateAPIDefs': this.createOrUpdateAPIDefs.bind(this),
-      'list:apidefs:registerClient': this.registerClient.bind(this),
-      'list:apidefs:generateToken': this.generateToken.bind(this),
-      'list:apidefs:listAPIDefs': this.listAPIDefs.bind(this),
-      'list:certs:registerClient': this.registerClient.bind(this),
-      'list:certs:generateToken': this.generateToken.bind(this),
-      'list:certs:listCerts': this.listCerts.bind(this),
-      'remove:apidefs:registerClient': this.registerClient.bind(this),
-      'remove:apidefs:generateToken': this.generateToken.bind(this),
-      'remove:apidefs:removeAPIDefs': this.removeAPIDefs.bind(this),
-      'remove:certs:registerClient': this.registerClient.bind(this),
-      'remove:certs:generateToken': this.generateToken.bind(this),
-      'remove:certs:removeCerts': this.removeCerts.bind(this),
+      'after:deploy:deploy': this.deploy.bind(this),
+      'after:info:info': this.info.bind(this),
+      'after:remove:remove': this.remove.bind(this)
     };
   };
 
-// -----------------------------------------
-// --- WSO2 API Manager version agnostic ---
-// -----------------------------------------
+  // -----------------------------------------
+  // --- WSO2 API Manager version agnostic ---
+  // -----------------------------------------
 
-// for sane code 🍻
-// ----------------
-// * Deals with URL of HTTP requests, so it can handle other versions of WSO2 API Manager too (at high-level)
-// * Acts as a first-mile bridge between Serverless Framework and WSO2 API Manager's dictionary
-// * Use no `console.log()` but use `this.serverless.cli.log()` 
-// * Use `throw new Error(err)` when you want the execution to halt!
-// -----------------
+  // for sane code 🍻
+  // ----------------
+  // * Deals with URL of HTTP requests, so it can handle other versions of WSO2 API Manager too (at high-level)
+  // * Acts as a first-mile bridge between Serverless Framework and WSO2 API Manager's dictionary
+  // * Use no `console.log()` but use `this.serverless.cli.log()` 
+  // * Use `throw new Error(err)` when you want the execution to halt!
+  // -----------------
+
+  async deploy() {
+    await this.validateConfig();
+    await this.registerClient();
+    await this.generateToken();
+    await this.uploadCerts();
+    // await this.createOrUpdateAPIDefs();
+  }
+  async info() {
+    await this.registerClient();
+    await this.generateToken();
+    await this.listAPIDefs();
+  }
+  async remove() {
+    await this.registerClient();
+    await this.generateToken();
+    await this.removeAPIDefs();
+  }
+
+  async validateConfig() {
+    this.serverless.cli.log(pluginNameSuffix + "Validating configuration..");
+    const wso2APIM = this.serverless.service.custom.wso2apim;
+    if ((wso2APIM.host == undefined) ||
+      (wso2APIM.port == undefined) ||
+      (wso2APIM.user == undefined) ||
+      (wso2APIM.pass == undefined) ||
+      (wso2APIM.apidefs == undefined)) {
+      this.serverless.cli.log(pluginNameSuffix + "Validating configuration.. NOT OK");
+      throw new Error();
+    }
+    else {
+      this.serverless.cli.log(pluginNameSuffix + "Validating configuration.. OK");
+    }
+  }
 
   async registerClient() {
+    this.serverless.cli.log(pluginNameSuffix + "Registering client..");
+    const wso2APIM = this.serverless.service.custom.wso2apim;
     try {
-      this.serverless.cli.log("Registering client..");
       const data = await wso2apim.registerClient(
-        "https://" + this.wso2APIM.host + ":" + this.wso2APIM.port + "/client-registration/" + this.wso2APIM.versionSlug + "/register",
-        this.wso2APIM.user,
-        this.wso2APIM.pass
+        "https://" + wso2APIM.host + ":" + wso2APIM.port + "/client-registration/" + wso2APIM.versionSlug + "/register",
+        wso2APIM.user,
+        wso2APIM.pass
       );
       this.cache.clientId = data.clientId;
       this.cache.clientSecret = data.clientSecret;
+      this.serverless.cli.log(pluginNameSuffix + "Registering client.. OK");
     }
     catch (err) {
-      this.serverless.cli.log("An error occurred during client registration.");
+      this.serverless.cli.log(pluginNameSuffix + "Registering client.. NOT OK");
       throw new Error(err);
     }
   }
 
   async generateToken() {
+    this.serverless.cli.log(pluginNameSuffix + "Generating temporary token..");
+    const wso2APIM = this.serverless.service.custom.wso2apim;
     try {
-      this.serverless.cli.log("Generating temporary token..\n");
       const data = await wso2apim.generateToken(
-        "https://" + this.wso2APIM.host + ":" + this.wso2APIM.port + "/oauth2/token",
-        this.wso2APIM.user,
-        this.wso2APIM.pass,
+        "https://" + wso2APIM.host + ":" + wso2APIM.port + "/oauth2/token",
+        wso2APIM.user,
+        wso2APIM.pass,
         this.cache.clientId,
         this.cache.clientSecret,
         "apim:api_create apim:api_publish apim:api_view apim:subscribe apim:tier_view apim:tier_manage apim:subscription_view apim:subscription_block",
       );
       this.cache.accessToken = data.accessToken;
+      this.serverless.cli.log(pluginNameSuffix + "Generating temporary token.. OK");
     }
-    catch(err) {
-      this.serverless.cli.log("An error occurred while generating temporary token.");
+    catch (err) {
+      this.serverless.cli.log(pluginNameSuffix + "Generating temporary token.. NOT OK");
       throw new Error(err);
     }
   }
@@ -171,7 +142,7 @@ class ServerlessPlugin {
         }
         catch (err) {
           if (err.response.data.code != '404') {
-            this.serverless.cli.log("An error occurred while listing backend certificate for " + `${apiDef.name}` + ", proceeding further.");
+            this.serverless.cli.log("Retrieving backend certificates.. NOT OK for " + `${apiDef.name}` + ", proceeding further.");
           }
           //Record certificate availability if not found
           this.cache.certAvailability.push({
@@ -183,6 +154,7 @@ class ServerlessPlugin {
           });
         }
       }
+      this.serverless.cli.log("Retrieving backend certificates.. OK");
       console.table(this.cache.certAvailability);
     }
     catch (err) {
@@ -207,6 +179,7 @@ class ServerlessPlugin {
           apiDef.version,
           apiDef.rootContext
         );
+        console.log("--is api deployed?", data);
 
         this.cache.deployedAPIs = [];
         // Loops thru all deployed api definitions returned from WSO2 API Manager (we need to find exact match out of 1:n results returned)
@@ -235,7 +208,7 @@ class ServerlessPlugin {
                 "https://" + this.wso2APIM.host + ":" + this.wso2APIM.port + "/api/am/store/" + this.wso2APIM.versionSlug + "/apis",
                 this.cache.accessToken,
                 apiId);
-              invokableAPIURL = data.endpointURLs.filter((Url) => { return Url.environmentName == this.wso2APIM.gatewayEnv })[0].environmentURLs.https; 
+              invokableAPIURL = data.endpointURLs.filter((Url) => { return Url.environmentName == this.wso2APIM.gatewayEnv })[0].environmentURLs.https;
             }
           }
           catch (err) {
@@ -257,50 +230,109 @@ class ServerlessPlugin {
             apiVersion: apiDef.version,
             apiContext: apiDef.rootContext,
             apiStatus: "TO BE CREATED",
-            apiId: null,
+            apiId: undefined,
             invokableAPIURL: "TO BE CREATED",
           })
         }
       }
       catch (err) {
-        this.serverless.cli.log("An error occurred while listing API deployment status.");
+        this.serverless.cli.log("Retrieving API Definitions.. NOT OK");
         throw new Error(err);
-        }
+      }
       this.cache.deployedAPIs = [];
     };
     if (this.cmd === 'list|apidefs')
-      console.table(this.cache.deploymentStatus);
+      this.serverless.cli.log("Retrieving API Definitions.. OK");
+    console.table(this.cache.deploymentStatus);
+  }
+
+  async detectAndSplitCerts(certChain) {
+    var certs = [];
+    // If certChain is provided as a file (relative to where serverless.yml is located)
+    if (certChain.startsWith("file://")) {
+      const certOutput = fs.readFileSync(certChain.split("file://")[1], "utf8");
+      certOutput.split("-----END CERTIFICATE-----\n").map((CA) => {
+        if (CA.length > 0) {
+          certs.push(CA + "-----END CERTIFICATE-----\n");
+        }
+      });
+      return certs;
+    }
+    // If certChain is provided as an AWS ACM ARN
+    else if (certChain.startsWith("arn:aws:acm:")) {
+      this.provider = this.serverless.getProvider('aws');
+      const certOutput = await this.provider.request('ACM', 'getCertificate', {
+        CertificateArn: certChain
+      });
+      if (certOutput) {
+        const leafCert = certOutput.Certificate;
+        const CAs = certOutput.CertificateChain;
+        // Push the leaf certificate to the list
+        certs.push(leafCert);
+        // Detect if multiple intermediary CAs are present in the CertificateChain
+        // Push the certificates (after splitting, if multiples are found in the chain)
+        CAs.split("-----END CERTIFICATE-----\n").map((CA) => {
+          if (CA.length > 0) {
+            certs.push(CA + "-----END CERTIFICATE-----\n");
+          }
+        });
+        return certs;
+      }
+      else {
+        return undefined;
+      }
+    }
   }
 
   async uploadCerts() {
+    const wso2APIM = this.serverless.service.custom.wso2apim;
+    const apiDefs = wso2APIM.apidefs;
+    const slsDir = this.serverless.config.servicePath + "/.serverless";
     try {
       // Loops thru each api definition found in serverless configuration
-      for (const [i, apiDef] of this.apiDefs.entries()) {
+      for (const [i, apiDef] of apiDefs.entries()) {
+        this.serverless.cli.log(pluginNameSuffix + "Uploading backend certificates for " + apiDef.name + "..");
+
         try {
-          // If backend is HTTPS and `publicCertChain` is present in serverless configuration
-          if (apiDef.backend.http.publicCertChain) {
-            // certAlias takes the form of <APIName>-<Version>
-            var certAlias = apiDef.name + "-" + apiDef.version;
-            this.serverless.cli.log("Uploading backend certificate for " + this.apiDefs[i].name + "..");
-            const data = await wso2apim.uploadCert(
-              "https://" + this.wso2APIM.host + ":" + this.wso2APIM.port + "/api/am/publisher/" + this.wso2APIM.versionSlug + "/certificates",
-              this.cache.accessToken,
-              certAlias,
-              apiDef.backend.http.publicCertChain,
-              apiDef.backend.http.baseUrl,
-            );
+          // certAlias takes the form of <APIName>|-|<Version>|-|<index>
+          let certs = await this.detectAndSplitCerts(apiDef.backend.http.certChain);
+
+          // Loop thru all certificates, e.g. Leaf cert, Intermediary CA, Root CA etc
+          // Create individual certificate files under /.serverless directory
+          if (certs.length > 0) {
+            certs.map(async (cert, j) => {
+              let certAlias = apiDef.name + "|-|" + apiDef.version + "|-|" + j;
+              let certFile = slsDir + "/" + certAlias + ".cer";
+              fs.writeFileSync(certFile, cert);
+
+              // Upload Cert to WSO2 API Manager
+              try {
+                await wso2apim.uploadCert(
+                  "https://" + wso2APIM.host + ":" + wso2APIM.port + "/api/am/publisher/" + wso2APIM.versionSlug + "/certificates",
+                  this.cache.accessToken,
+                  certAlias,
+                  certFile,
+                  apiDef.backend.http.baseUrl
+                );
+                this.serverless.cli.log(pluginNameSuffix + "Uploading certificate #" + j + " .. OK");
+              }
+              catch (err) {
+                if (err.response.data.code != '409') {
+                  this.serverless.cli.log(pluginNameSuffix + "Uploading certificate #" + j + " .. NOT OK, proceeding further");
+                }
+              }
+            });
+            this.serverless.cli.log(pluginNameSuffix + "Uploading backend certificates for " + apiDef.name + ".. OK");
           }
         }
         catch (err) {
-          // Ignore Certificate-exists-for-that-Alias error gracefully
           if (err.response.data.code != '409') {
-            this.serverless.cli.log("An error occurred while uploading backend certificate for " + `${this.apiDefs[i].name}` + ", proceeding further.");
+            this.serverless.cli.log(pluginNameSuffix + "Uploading backend certificates for " + apiDef.name + ".. NOT OK, proceeding further.");
           }
         }
       }
     }
     catch (err) {
-      this.serverless.cli.log("An error occurred while uploading certificates.");
       throw new Error(err);
     }
   }
@@ -324,6 +356,7 @@ class ServerlessPlugin {
               this.apiDefs[i],
               api.apiId
             );
+            this.serverless.cli.log("Updating " + this.apiDefs[i].name + " (" + api.apiId + ").. OK");
           }
           else {
             this.serverless.cli.log("Creating " + this.apiDefs[i].name + "..");
@@ -334,15 +367,17 @@ class ServerlessPlugin {
               this.wso2APIM.gatewayEnv,
               this.apiDefs[i]
             );
+            this.serverless.cli.log("Creating " + this.apiDefs[i].name + ".. OK");
           }
         }
         catch (err) {
-          this.serverless.cli.log("An error occurred while creating / updating " + `${this.apiDefs[i].name}` + ", proceeding further.");
+          this.serverless.cli.log("Creating / Updating " + `${this.apiDefs[i].name}` + ".. NOT OK, proceeding further.");
         }
       }
 
       // By calling listAPIDefs(), we are re-collecting the current deployment status in WSO2 API Manager
       await this.listAPIDefs();
+      console.log("--- after creating/updating, before publishing", this.cache.deploymentStatus);
 
       // Publish or Re-Publish API definitions, based on whether they are in CREATED or PUBLISHED states
       for (const [i, api] of this.cache.deploymentStatus.entries()) {
@@ -359,15 +394,16 @@ class ServerlessPlugin {
               this.cache.accessToken,
               api.apiId
             );
+            this.serverless.cli.log("Publishing / Re-publishing " + this.apiDefs[i].name + " (" + api.apiId + ").. OK");
           }
         }
         catch (err) {
-          this.serverless.cli.log("An error occurred while publishing / republishing " + `${this.apiDefs[i].name}` + ", proceeding further.");
+          this.serverless.cli.log("Publishing / Re-publishing " + this.apiDefs[i].name + " (" + api.apiId + ").. NOT OK, proceeding further.");
         }
       }
     }
     catch (err) {
-      this.serverless.cli.log("An error occurred while creating / updating API definitions.");
+      this.serverless.cli.log("Creating / Updating API definitions.. NOT OK");
       throw new Error(err);
     }    
     this.serverless.cli.log("Deployment complete. \n   Use `sls list apidefs` to view the deployment status.");
@@ -386,12 +422,13 @@ class ServerlessPlugin {
             this.cache.accessToken,
             api.apiId
           );
+          this.serverless.cli.log("Deleting " + api.apiId + ".. OK");
         }
       };
       this.serverless.cli.log("Removal complete. \n Use `sls list apidefs` to view the deployment status.");
     }
     catch(err) {
-      this.serverless.cli.log("An error occurred while removing API definitions.");
+      this.serverless.cli.log("Deleting API defintions.. NOT OK");
       throw new Error(err);
     }
   }
@@ -412,7 +449,6 @@ class ServerlessPlugin {
           );
         }
         catch (err) {
-          console.log(err);
           // Ignore Certificate-not-found-for-that-Alias error gracefully
           if (err.response.data.code != '404') {
             this.serverless.cli.log("An error occurred while removing backend certificate for " + `${this.apiDefs[i].name}` + ", proceeding further.");
@@ -429,4 +465,4 @@ class ServerlessPlugin {
 
 }
 
-module.exports = ServerlessPlugin;
+module.exports = Serverless_WSO2_APIM;

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ class Serverless_WSO2_APIM {
   }
 
   async validateConfig() {
-    this.serverless.cli.log(pluginNameSuffix + "Validating configuration..");
+    // this.serverless.cli.log(pluginNameSuffix + "Validating configuration..");
     const wso2APIM = this.serverless.service.custom.wso2apim;
     if ((wso2APIM.host == undefined) ||
       (wso2APIM.port == undefined) ||
@@ -75,7 +75,7 @@ class Serverless_WSO2_APIM {
   }
 
   async registerClient() {
-    this.serverless.cli.log(pluginNameSuffix + "Registering client..");
+    // this.serverless.cli.log(pluginNameSuffix + "Registering client..");
     const wso2APIM = this.serverless.service.custom.wso2apim;
     try {
       const data = await wso2apim.registerClient(
@@ -94,7 +94,7 @@ class Serverless_WSO2_APIM {
   }
 
   async generateToken() {
-    this.serverless.cli.log(pluginNameSuffix + "Generating temporary token..");
+    // this.serverless.cli.log(pluginNameSuffix + "Generating temporary token..");
     const wso2APIM = this.serverless.service.custom.wso2apim;
     try {
       const data = await wso2apim.generateToken(
@@ -162,9 +162,9 @@ class Serverless_WSO2_APIM {
 
 
   async listAPIDefs() {
-    if (this.cmd === 'info')
-      this.serverless.cli.log(pluginNameSuffix + "Retrieving API Definitions..");
-
+    if (this.cmd === 'info') {
+      // this.serverless.cli.log(pluginNameSuffix + "Retrieving API Definitions..");
+    }
     const wso2APIM = this.serverless.service.custom.wso2apim;
     const apiDefs = wso2APIM.apidefs;
 
@@ -253,7 +253,7 @@ class Serverless_WSO2_APIM {
     };
 
     if (this.cmd === 'info') {
-      this.serverless.cli.log("Retrieving API Definitions.. OK");
+      this.serverless.cli.log(pluginNameSuffix + "Retrieving API Definitions.. OK");
       console.table(this.cache.deploymentStatus);
     }
   }
@@ -303,7 +303,7 @@ class Serverless_WSO2_APIM {
     try {
       // Loops thru each api definition found in serverless configuration
       for (const [i, apiDef] of apiDefs.entries()) {
-        this.serverless.cli.log(pluginNameSuffix + "Uploading backend certificates for " + apiDef.name + "..");
+        // this.serverless.cli.log(pluginNameSuffix + "Uploading backend certificates for " + apiDef.name + "..");
 
         try {
           // certAlias takes the form of <APIName>|-|<Version>|-|<index>
@@ -370,7 +370,7 @@ class Serverless_WSO2_APIM {
         try {
           //Update
           if (api.apiId !== undefined) {
-            this.serverless.cli.log(pluginNameSuffix + "Updating " + api.apiName + " (" + api.apiId + ")..");
+            // this.serverless.cli.log(pluginNameSuffix + "Updating " + api.apiName + " (" + api.apiId + ")..");
             const data = await wso2apim.updateAPIDef(
               "https://" + wso2APIM.host + ":" + wso2APIM.port + "/api/am/publisher/" + wso2APIM.versionSlug + "/apis",
               wso2APIM.user,
@@ -383,7 +383,7 @@ class Serverless_WSO2_APIM {
           }
           //Create
           else {
-            this.serverless.cli.log(pluginNameSuffix + "Creating " + api.apiName + "..");
+            // this.serverless.cli.log(pluginNameSuffix + "Creating " + api.apiName + "".."");
             const data = await wso2apim.createAPIDef(
               "https://" + wso2APIM.host + ":" + wso2APIM.port + "/api/am/publisher/" + wso2APIM.versionSlug + "/apis",
               wso2APIM.user,
@@ -406,10 +406,10 @@ class Serverless_WSO2_APIM {
         try {
           if (api.apiId !== undefined) {
             if (api.apiStatus === 'CREATED') {
-              this.serverless.cli.log(pluginNameSuffix + "Publishing " + api.apiName + " (" + api.apiId + ")..");
+              // this.serverless.cli.log(pluginNameSuffix + "Publishing " + api.apiName + " (" + api.apiId + ")..");
             }
             else if (api.apiStatus === 'PUBLISHED') {
-              this.serverless.cli.log(pluginNameSuffix + "Re-publishing " + api.apiName + " (" + api.apiId + ")..");
+              // this.serverless.cli.log(pluginNameSuffix + "Re-publishing " + api.apiName + " (" + api.apiId + ")..");
             }
             const data = await wso2apim.publishAPIDef(
               "https://" + wso2APIM.host + ":" + wso2APIM.port + "/api/am/publisher/" + wso2APIM.versionSlug + "/apis/change-lifecycle",
@@ -428,7 +428,9 @@ class Serverless_WSO2_APIM {
       this.serverless.cli.log(pluginNameSuffix + "Creating / Updating API definitions.. NOT OK");
       throw new Error(err);
     }    
-    this.serverless.cli.log(pluginNameSuffix + "Deployment complete. Use `sls info` to view the deployment status.");
+    this.serverless.cli.log(pluginNameSuffix + "Creating / Updating API definitions.. OK");
+    await this.listAPIDefs();
+    console.table(this.cache.deploymentStatus);
   }
 
 
@@ -438,7 +440,7 @@ class Serverless_WSO2_APIM {
       await this.listAPIDefs(); 
       for (let api of this.cache.deploymentStatus) {
         if (api.apiId !== undefined) {
-          this.serverless.cli.log("Deleting " + api.apiId + "..");
+          // this.serverless.cli.log("Deleting " + api.apiId + "..");
           const data = await wso2apim.removeAPIDef(
             "https://" + this.wso2APIM.host + ":" + this.wso2APIM.port + "/api/am/publisher/" + this.wso2APIM.versionSlug + "/apis",
             this.cache.accessToken,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4721,6 +4721,11 @@ spawn-to-readstream@~0.1.3:
     limit-spawn "0.0.3"
     through2 "~0.4.1"
 
+split-ca@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split-ca/-/split-ca-1.0.1.tgz#6c83aff3692fa61256e0cd197e05e9de157691a6"
+  integrity sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY=
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"


### PR DESCRIPTION
* Major command changes to note:
  Main motivation is to keep it aligned with how serverless commands are widely used.  
  a. `sls deploy` will deploy API definitions (and backend certificates associated) in WSO2 API Manager along with your other Serverless resources  
  b. `sls info` will list the deployment status of API definitions in WSO2 API Manager  
  c. `sls remove` will remove API definitions (and backend certificates associated) in WSO2 API Manager  

* All the parameters under `custom : wso2apim` now supports Serverless variables, AWS SSM parameters which are generally supported by Serverless Framework as described [here](https://www.serverless.com/framework/docs/providers/aws/guide/variables/).  

* `certChain` now accepts certificate chain in two formats
  a. AWS ACM Certificat ARN (e.g. `arn:aws:acm:...`)  
  b. local file (e.g. `file://certs/abc.cer`) relatively from where `serverless.yml` file is located   
  