### PR TITLE
fix: disable validation when enabled is false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,14 @@ class Serverless_WSO2_APIM {
     try {
       // this.serverless.cli.log(pluginNameSuffix + "Validating configuration..");
       const wso2APIM = this.serverless.service.custom.wso2apim;
-
+      if (wso2APIM.enabled === false) {
+        this.serverless.cli.log(
+          pluginNameSuffix +
+          'Validation is disabled, Skipping.. OK'
+        );
+        return;
+      }
+      
       // Key value checks, with corresponding error messages
       const conditionsArray = [
         ((typeof wso2APIM.enabled === 'undefined') || (typeof wso2APIM.enabled === 'boolean')),

--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ class Serverless_WSO2_APIM {
       if (wso2APIM.enabled === false) {
         this.serverless.cli.log(
           pluginNameSuffix +
-          'Validation is disabled, Skipping.. OK'
+          'Configuration is disabled globally, Skipping validation.. OK'
         );
         return;
       }


### PR DESCRIPTION
Hi Ram.

Thanks for this plugin. I am proposing this change because I do not know if there is another way. Please tell me what do you think.

We are using `enabled: false` to completely skip wso2 deploy when it is a local environment (LocalStack).

If validation is not skipped in this case, we get invalid configuration errors.

