### PR TITLE
CORS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ or
 | `maxTps` | Max. Transactions per second, used for throttling. | `100` |
 | `cors` | Optional, a CORS configuration to enable. Omit this property to disable CORS. See below for properties. | |
 | `cors.origins` | String array of allowed origins. Default: `['*']` | |
-| `cors.headers` | String array of allowed headers. Default: `['authorization', 'Access-Control-Allow-Origin', 'Content-Type', 'SOAPAction', 'apikey']` | |
+| `cors.headers` | String array of allowed headers. Default: `['Authorization', 'Access-Control-Allow-Origin', 'Content-Type', 'SOAPAction']` | |
 | `cors.methods` | String array of allowed methods. Default: `['GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS']` | |
 | `cors.credentials` | Allow credentials (boolean). Default: `false` | `true` |
 | `tags` | Tags as an array that show up in WSO2 console. | |

--- a/README.md
+++ b/README.md
@@ -159,10 +159,15 @@ or
 | `mediationPolicies.fault` | Fault mediation policy, it manipulates the fault handling. | `None` |
 | `apiProperties` | Optional, List of API properties to be used in `key`:`value` form as described [here](https://docs.wso2.com/display/AM260/Adding+Custom+Properties+to+APIs). | `'property1': 'value1'`|
 | `maxTps` | Max. Transactions per second, used for throttling. | `100` |
+| `cors` | Optional, a CORS configuration to enable. Omit this property to disable CORS. See below for properties. | |
+| `cors.origins` | String array of allowed origins. Default: `['*']` | |
+| `cors.headers` | String array of allowed headers. Default: `['authorization', 'Access-Control-Allow-Origin', 'Content-Type', 'SOAPAction', 'apikey']` | |
+| `cors.methods` | String array of allowed methods. Default: `['GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS']` | |
+| `cors.credentials` | Allow credentials (boolean). Default: `false` | `true` |
 | `tags` | Tags as an array that show up in WSO2 console. | |
 | `swaggerSpec` | Swagger 2.0 / OpenAPI 3.0 specification in YML | |
 
----
+
 ## 💡Tip : Organize your project files efficiently.
 
 You can spread the configuration across multiple files, so you can manage it better. Bonus, you can use linters and validators effectively on your swaggerSpec.

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -577,6 +577,7 @@ module.exports = {
   isCertUploaded,
   createAPIDef,
   publishAPIDef,
+  constructAPIDef,
   uploadCert,
   updateCert,
   removeCert,

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -253,11 +253,10 @@ function constructAPIDef(user, gatewayEnv, apiDef, apiId) {
 function constructCorsConfiguration(apiDef) {
   const { origins, credentials, headers, methods } = apiDef.cors;
   const defaultAllowHeaders /* default WSO2 cors config */ = [
-    'authorization',
+    'Authorization',
     'Access-Control-Allow-Origin',
     'Content-Type',
     'SOAPAction',
-    'apikey',
   ];
   const defaultAllowMethods /* default WSO2 cors config */ = [
     'GET',

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -236,6 +236,9 @@ function constructAPIDef(user, gatewayEnv, apiDef, apiId) {
         businessOwner: ((apiDef.swaggerSpec.info) && (apiDef.swaggerSpec.info.contact) && (apiDef.swaggerSpec.info.contact.name)) ? apiDef.swaggerSpec.info.contact.name : undefined,
       }
     };
+    if (apiDef.cors) {
+      wso2ApiDefinition.corsConfiguration = constructCorsConfiguration(apiDef);
+    }
 
     backendBaseUrl = '';
     backendType = '';
@@ -245,6 +248,32 @@ function constructAPIDef(user, gatewayEnv, apiDef, apiId) {
   catch (err) {
     utils.renderError(err);
   }
+}
+
+function constructCorsConfiguration(apiDef) {
+  const { origins, credentials, headers, methods } = apiDef.cors;
+  const defaultAllowHeaders /* default WSO2 cors config */ = [
+    'authorization',
+    'Access-Control-Allow-Origin',
+    'Content-Type',
+    'SOAPAction',
+    'apikey',
+  ];
+  const defaultAllowMethods /* default WSO2 cors config */ = [
+    'GET',
+    'PUT',
+    'POST',
+    'DELETE',
+    'PATCH',
+    'OPTIONS',
+  ];
+  return {
+    corsConfigurationEnabled: true,
+    accessControlAllowOrigins: origins || ['*'],
+    accessControlAllowCredentials: credentials || false,
+    accessControlAllowHeaders: headers || defaultAllowHeaders,
+    accessControlAllowMethods: methods || defaultAllowMethods,
+  };
 }
 
 // Creates API definition

--- a/src/2.6.0/wso2apim.spec.js
+++ b/src/2.6.0/wso2apim.spec.js
@@ -518,11 +518,10 @@ describe('wso2apim-2.6.0', () => {
         accessControlAllowOrigins: [ 'https://www.example.com' ],
         accessControlAllowCredentials: false,
         accessControlAllowHeaders: [
-          'authorization',
+          'Authorization',
           'Access-Control-Allow-Origin',
           'Content-Type',
-          'SOAPAction',
-          'apikey'
+          'SOAPAction'
         ],
         accessControlAllowMethods: [ 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS' ]
       });
@@ -532,7 +531,7 @@ describe('wso2apim-2.6.0', () => {
       const config = {...wso2APIM, apidefs: [{...wso2APIM.apidefs[0], cors: {
         origins: ['https://www.example.com', 'https://www.example.org'],
         credentials: true,
-        headers: ['autorization', 'x-custom'],
+        headers: ['Authorization', 'x-custom'],
         methods: ['GET']
       }}]};
 
@@ -542,7 +541,7 @@ describe('wso2apim-2.6.0', () => {
         corsConfigurationEnabled: true,
         accessControlAllowOrigins: [ 'https://www.example.com', 'https://www.example.org' ],
         accessControlAllowCredentials: true,
-        accessControlAllowHeaders: ['autorization', 'x-custom'],
+        accessControlAllowHeaders: ['Authorization', 'x-custom'],
         accessControlAllowMethods: ['GET']
       });
     });

--- a/src/2.6.0/wso2apim.spec.js
+++ b/src/2.6.0/wso2apim.spec.js
@@ -5,6 +5,7 @@ const {
   isCertUploaded,
   createAPIDef,
   publishAPIDef,
+  constructAPIDef,
   uploadCert,
   updateCert,
   removeCert,
@@ -495,6 +496,56 @@ describe('wso2apim-2.6.0', () => {
       expect(listCertInfo(wso2APIM, 'xxx', 'alias')).rejects.toThrow();
     });
 
+  });
+
+  describe('cors configuration', () => {
+
+    it('no cors', async () => {
+      const apiDef = await constructAPIDef(wso2APIM.user, wso2APIM.gatewayEnv, wso2APIM.apidefs[0]);
+
+      expect(apiDef.corsConfiguration).toBeUndefined();
+    });
+
+    it('only origin', async () => {
+      const config = {...wso2APIM, apidefs: [{...wso2APIM.apidefs[0], cors: {
+        origins: ['https://www.example.com']
+      }}]};
+
+      const apiDef = await constructAPIDef(config.user, config.gatewayEnv, config.apidefs[0]);
+
+      expect(apiDef.corsConfiguration).toEqual({
+        corsConfigurationEnabled: true,
+        accessControlAllowOrigins: [ 'https://www.example.com' ],
+        accessControlAllowCredentials: false,
+        accessControlAllowHeaders: [
+          'authorization',
+          'Access-Control-Allow-Origin',
+          'Content-Type',
+          'SOAPAction',
+          'apikey'
+        ],
+        accessControlAllowMethods: [ 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS' ]
+      });
+    });
+
+    it('fully specified', async () => {
+      const config = {...wso2APIM, apidefs: [{...wso2APIM.apidefs[0], cors: {
+        origins: ['https://www.example.com', 'https://www.example.org'],
+        credentials: true,
+        headers: ['autorization', 'x-custom'],
+        methods: ['GET']
+      }}]};
+
+      const apiDef = await constructAPIDef(config.user, config.gatewayEnv, config.apidefs[0]);
+
+      expect(apiDef.corsConfiguration).toEqual({
+        corsConfigurationEnabled: true,
+        accessControlAllowOrigins: [ 'https://www.example.com', 'https://www.example.org' ],
+        accessControlAllowCredentials: true,
+        accessControlAllowHeaders: ['autorization', 'x-custom'],
+        accessControlAllowMethods: ['GET']
+      });
+    });
   });
   
 });

--- a/src/3.2.0/wso2apim.js
+++ b/src/3.2.0/wso2apim.js
@@ -255,11 +255,10 @@ async function constructAPIDef(user, gatewayEnv, apiDef, apiId) {
 function constructCorsConfiguration(apiDef) {
   const { origins, credentials, headers, methods } = apiDef.cors;
   const defaultAllowHeaders /* default WSO2 cors config */ = [
-    'authorization',
+    'Authorization',
     'Access-Control-Allow-Origin',
     'Content-Type',
     'SOAPAction',
-    'apikey',
   ];
   const defaultAllowMethods /* default WSO2 cors config */ = [
     'GET',

--- a/src/3.2.0/wso2apim.js
+++ b/src/3.2.0/wso2apim.js
@@ -615,6 +615,7 @@ module.exports = {
   isCertUploaded,
   createAPIDef,
   publishAPIDef,
+  constructAPIDef,
   uploadCert,
   updateCert,
   removeCert,

--- a/src/3.2.0/wso2apim.js
+++ b/src/3.2.0/wso2apim.js
@@ -238,6 +238,9 @@ async function constructAPIDef(user, gatewayEnv, apiDef, apiId) {
         businessOwner: ((apiDef.swaggerSpec.info) && (apiDef.swaggerSpec.info.contact) && (apiDef.swaggerSpec.info.contact.name)) ? apiDef.swaggerSpec.info.contact.name : undefined,
       }
     };
+    if (apiDef.cors) {
+      wso2ApiDefinition.corsConfiguration = constructCorsConfiguration(apiDef);
+    }
 
     backendBaseUrl = '';
     backendType = '';
@@ -247,6 +250,32 @@ async function constructAPIDef(user, gatewayEnv, apiDef, apiId) {
   catch (err) {
     utils.renderError(err);
   }
+}
+
+function constructCorsConfiguration(apiDef) {
+  const { origins, credentials, headers, methods } = apiDef.cors;
+  const defaultAllowHeaders /* default WSO2 cors config */ = [
+    'authorization',
+    'Access-Control-Allow-Origin',
+    'Content-Type',
+    'SOAPAction',
+    'apikey',
+  ];
+  const defaultAllowMethods /* default WSO2 cors config */ = [
+    'GET',
+    'PUT',
+    'POST',
+    'DELETE',
+    'PATCH',
+    'OPTIONS',
+  ];
+  return {
+    corsConfigurationEnabled: true,
+    accessControlAllowOrigins: origins || ['*'],
+    accessControlAllowCredentials: credentials || false,
+    accessControlAllowHeaders: headers || defaultAllowHeaders,
+    accessControlAllowMethods: methods || defaultAllowMethods,
+  };
 }
 
 async function constructAPIOperations(apiDef) {

--- a/src/3.2.0/wso2apim.spec.js
+++ b/src/3.2.0/wso2apim.spec.js
@@ -5,6 +5,7 @@ const {
   isCertUploaded,
   createAPIDef,
   publishAPIDef,
+  constructAPIDef,
   uploadCert,
   updateCert,
   removeCert,
@@ -516,6 +517,56 @@ describe('wso2apim-3.2.0', () => {
       expect(listCertInfo(wso2APIM, 'xxx', 'alias')).rejects.toThrow();
     });
 
+  });
+
+  describe('cors configuration', () => {
+
+    it('no cors', async () => {
+      const apiDef = await constructAPIDef(wso2APIM.user, wso2APIM.gatewayEnv, wso2APIM.apidefs[0]);
+
+      expect(apiDef.corsConfiguration).toBeUndefined();
+    });
+
+    it('only origin', async () => {
+      const config = {...wso2APIM, apidefs: [{...wso2APIM.apidefs[0], cors: {
+        origins: ['https://www.example.com']
+      }}]};
+
+      const apiDef = await constructAPIDef(config.user, config.gatewayEnv, config.apidefs[0]);
+
+      expect(apiDef.corsConfiguration).toEqual({
+        corsConfigurationEnabled: true,
+        accessControlAllowOrigins: [ 'https://www.example.com' ],
+        accessControlAllowCredentials: false,
+        accessControlAllowHeaders: [
+          'authorization',
+          'Access-Control-Allow-Origin',
+          'Content-Type',
+          'SOAPAction',
+          'apikey'
+        ],
+        accessControlAllowMethods: [ 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS' ]
+      });
+    });
+
+    it('fully specified', async () => {
+      const config = {...wso2APIM, apidefs: [{...wso2APIM.apidefs[0], cors: {
+        origins: ['https://www.example.com', 'https://www.example.org'],
+        credentials: true,
+        headers: ['autorization', 'x-custom'],
+        methods: ['GET']
+      }}]};
+
+      const apiDef = await constructAPIDef(config.user, config.gatewayEnv, config.apidefs[0]);
+
+      expect(apiDef.corsConfiguration).toEqual({
+        corsConfigurationEnabled: true,
+        accessControlAllowOrigins: [ 'https://www.example.com', 'https://www.example.org' ],
+        accessControlAllowCredentials: true,
+        accessControlAllowHeaders: ['autorization', 'x-custom'],
+        accessControlAllowMethods: ['GET']
+      });
+    });
   });
   
 });

--- a/src/3.2.0/wso2apim.spec.js
+++ b/src/3.2.0/wso2apim.spec.js
@@ -539,11 +539,10 @@ describe('wso2apim-3.2.0', () => {
         accessControlAllowOrigins: [ 'https://www.example.com' ],
         accessControlAllowCredentials: false,
         accessControlAllowHeaders: [
-          'authorization',
+          'Authorization',
           'Access-Control-Allow-Origin',
           'Content-Type',
-          'SOAPAction',
-          'apikey'
+          'SOAPAction'
         ],
         accessControlAllowMethods: [ 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'OPTIONS' ]
       });
@@ -553,7 +552,7 @@ describe('wso2apim-3.2.0', () => {
       const config = {...wso2APIM, apidefs: [{...wso2APIM.apidefs[0], cors: {
         origins: ['https://www.example.com', 'https://www.example.org'],
         credentials: true,
-        headers: ['autorization', 'x-custom'],
+        headers: ['Authorization', 'x-custom'],
         methods: ['GET']
       }}]};
 
@@ -563,7 +562,7 @@ describe('wso2apim-3.2.0', () => {
         corsConfigurationEnabled: true,
         accessControlAllowOrigins: [ 'https://www.example.com', 'https://www.example.org' ],
         accessControlAllowCredentials: true,
-        accessControlAllowHeaders: ['autorization', 'x-custom'],
+        accessControlAllowHeaders: ['Authorization', 'x-custom'],
         accessControlAllowMethods: ['GET']
       });
     });

--- a/src/__tests__/e2e/e2e.test.js
+++ b/src/__tests__/e2e/e2e.test.js
@@ -70,8 +70,11 @@ describe('E2E on WSO2 API Manager', () => {
             else if (testCase.split('-')[0] === 'invalid') {
               console.log("Cleaning up... ", chalk.bold.underline(`🌧 ${wso2ApimVersion}/${testCase}`), "\n\n", procRemove.output.toString());
             }
-            expect(procRemove.status).toBe(0);
-            expect(procRemove.output.toString()).toEqual(expect.not.stringContaining('NOT OK'));
+            const isTestCaseWithInvalidConfig = testCase.split('-')[0] === 'invalid' && procRemove.output.toString().includes('Validating configuration.. NOT OK');
+            if (!isTestCaseWithInvalidConfig) {
+              expect(procRemove.status).toBe(0);
+              expect(procRemove.output.toString()).toEqual(expect.not.stringContaining('NOT OK'));
+            }
           });
         }
         else {

--- a/src/__tests__/e2e/invalid-cors-configuration/serverless.yml
+++ b/src/__tests__/e2e/invalid-cors-configuration/serverless.yml
@@ -1,0 +1,66 @@
+service: serverless-wso2-apim
+provider:
+  name: aws
+  stackName: ${env:STACK_NAME}
+  deploymentBucket:
+    name: ${env:TEST_ID_NORMALIZED}
+plugins:
+  - serverless-localstack
+  - serverless-deployment-bucket
+  - '../../../../src'
+
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ Modify the configuration below to suit your test case.
+#⬇⬇⬇ START HERE ⬇⬇⬇⬇ Help: https://github.com/ramgrandhi/serverless-wso2-apim#configuration-reference
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ For a full list of env vars that you can use, refer `src/__tests__/e2e/e2e.test.js`
+custom:
+  wso2apim:
+    enabled: true
+    host: ${env:WSO2_HOST}
+    port: ${env:WSO2_PORT}
+    user: ${env:WSO2_USER}
+    pass: ${env:WSO2_PASS}
+    gatewayEnv: ${env:WSO2_ENV}
+    apidefs:
+      - name: ${env:TEST_ID}-1
+        description: ${env:TEST_ID}-1
+        rootContext: /${env:TEST_ID}-1
+        version: '1'
+        visibility: 'PRIVATE'
+        backend:
+          http:
+            baseUrl: 'https://baseUrl'
+        maxTps: 10
+        tags:
+          - ${env:TEST_ID}-1
+        cors:
+          origins:
+            - https://example.com
+          methods:
+            - GET
+            - POST
+          headers:
+            - authorization
+            - x-test
+          credentials: invalid
+        swaggerSpec:
+          openapi: 3.0.0
+          info:
+            title: ${env:TEST_ID}-1
+            version: "1"
+            contact:
+              name: ${env:TEST_ID}-1
+              email: ${env:TEST_ID}-1
+          paths:
+            /*:
+              post:
+                responses:
+                  "201":
+                    description: Created
+                x-auth-type: 'None'
+
+# Optionally, add your other AWS provider-specific resources below. 
+# Make sure there is at least one resource listed below, otherwise stack deployment would fail.
+resources:
+  Resources:
+    Topic:
+      Type: AWS::SNS::Topic

--- a/src/__tests__/e2e/valid-cors-configuration-full/serverless.yml
+++ b/src/__tests__/e2e/valid-cors-configuration-full/serverless.yml
@@ -34,13 +34,13 @@ custom:
           - ${env:TEST_ID}-1
         cors:
           origins:
-            - https://nn.nl
+            - https://example.com
           methods:
             - GET
             - POST
           headers:
             - authorization
-            - x-nn-test
+            - x-test
           credentials: true
         swaggerSpec:
           openapi: 3.0.0

--- a/src/__tests__/e2e/valid-cors-configuration-full/serverless.yml
+++ b/src/__tests__/e2e/valid-cors-configuration-full/serverless.yml
@@ -1,0 +1,66 @@
+service: serverless-wso2-apim
+provider:
+  name: aws
+  stackName: ${env:STACK_NAME}
+  deploymentBucket:
+    name: ${env:TEST_ID_NORMALIZED}
+plugins:
+  - serverless-localstack
+  - serverless-deployment-bucket
+  - '../../../../src'
+
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ Modify the configuration below to suit your test case.
+#⬇⬇⬇ START HERE ⬇⬇⬇⬇ Help: https://github.com/ramgrandhi/serverless-wso2-apim#configuration-reference
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ For a full list of env vars that you can use, refer `src/__tests__/e2e/e2e.test.js`
+custom:
+  wso2apim:
+    enabled: true
+    host: ${env:WSO2_HOST}
+    port: ${env:WSO2_PORT}
+    user: ${env:WSO2_USER}
+    pass: ${env:WSO2_PASS}
+    gatewayEnv: ${env:WSO2_ENV}
+    apidefs:
+      - name: ${env:TEST_ID}-1
+        description: ${env:TEST_ID}-1
+        rootContext: /${env:TEST_ID}-1
+        version: '1'
+        visibility: 'PRIVATE'
+        backend:
+          http:
+            baseUrl: 'https://baseUrl'
+        maxTps: 10
+        tags:
+          - ${env:TEST_ID}-1
+        cors:
+          origins:
+            - https://nn.nl
+          methods:
+            - GET
+            - POST
+          headers:
+            - authorization
+            - x-nn-test
+          credentials: true
+        swaggerSpec:
+          openapi: 3.0.0
+          info:
+            title: ${env:TEST_ID}-1
+            version: "1"
+            contact:
+              name: ${env:TEST_ID}-1
+              email: ${env:TEST_ID}-1
+          paths:
+            /*:
+              post:
+                responses:
+                  "201":
+                    description: Created
+                x-auth-type: 'None'
+
+# Optionally, add your other AWS provider-specific resources below. 
+# Make sure there is at least one resource listed below, otherwise stack deployment would fail.
+resources:
+  Resources:
+    Topic:
+      Type: AWS::SNS::Topic

--- a/src/__tests__/e2e/valid-cors-configuration-only-origin/serverless.yml
+++ b/src/__tests__/e2e/valid-cors-configuration-only-origin/serverless.yml
@@ -34,7 +34,7 @@ custom:
           - ${env:TEST_ID}-1
         cors:
           origins:
-            - https://nn.nl
+            - https://example.com
         swaggerSpec:
           openapi: 3.0.0
           info:

--- a/src/__tests__/e2e/valid-cors-configuration-only-origin/serverless.yml
+++ b/src/__tests__/e2e/valid-cors-configuration-only-origin/serverless.yml
@@ -1,0 +1,59 @@
+service: serverless-wso2-apim
+provider:
+  name: aws
+  stackName: ${env:STACK_NAME}
+  deploymentBucket:
+    name: ${env:TEST_ID_NORMALIZED}
+plugins:
+  - serverless-localstack
+  - serverless-deployment-bucket
+  - '../../../../src'
+
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ Modify the configuration below to suit your test case.
+#⬇⬇⬇ START HERE ⬇⬇⬇⬇ Help: https://github.com/ramgrandhi/serverless-wso2-apim#configuration-reference
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ For a full list of env vars that you can use, refer `src/__tests__/e2e/e2e.test.js`
+custom:
+  wso2apim:
+    enabled: true
+    host: ${env:WSO2_HOST}
+    port: ${env:WSO2_PORT}
+    user: ${env:WSO2_USER}
+    pass: ${env:WSO2_PASS}
+    gatewayEnv: ${env:WSO2_ENV}
+    apidefs:
+      - name: ${env:TEST_ID}-1
+        description: ${env:TEST_ID}-1
+        rootContext: /${env:TEST_ID}-1
+        version: '1'
+        visibility: 'PRIVATE'
+        backend:
+          http:
+            baseUrl: 'https://baseUrl'
+        maxTps: 10
+        tags:
+          - ${env:TEST_ID}-1
+        cors:
+          origins:
+            - https://nn.nl
+        swaggerSpec:
+          openapi: 3.0.0
+          info:
+            title: ${env:TEST_ID}-1
+            version: "1"
+            contact:
+              name: ${env:TEST_ID}-1
+              email: ${env:TEST_ID}-1
+          paths:
+            /*:
+              post:
+                responses:
+                  "201":
+                    description: Created
+                x-auth-type: 'None'
+
+# Optionally, add your other AWS provider-specific resources below. 
+# Make sure there is at least one resource listed below, otherwise stack deployment would fail.
+resources:
+  Resources:
+    Topic:
+      Type: AWS::SNS::Topic

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,10 @@ class Serverless_WSO2_APIM {
         ((wso2APIM.user) && (wso2APIM.user.length > 0)),
         ((wso2APIM.pass) && (wso2APIM.pass.length > 0)),
         ((wso2APIM.gatewayEnv) && (wso2APIM.gatewayEnv.length > 0)),
-        (wso2APIM.apidefs.length > 0)
+        (wso2APIM.apidefs.length > 0),
+        (wso2APIM.apidefs.every(def => typeof def.cors === 'undefined' ||
+          (typeof def.cors.credentials === 'undefined' || typeof def.cors.credentials === 'boolean'))
+        )
       ];
       const messagesArray = [
         'Invalid value assigned to `custom.wso2apim.enabled`',
@@ -180,6 +183,7 @@ class Serverless_WSO2_APIM {
         'Invalid value assigned to `custom.wso2apim.pass`',
         'Invalid value assigned to `custom.wso2apim.gatewayEnv`',
         'No API definitions supplied `custom.wso2apim.apidefs`',
+        'Invalid value assigned to `custom.wso2apim.apiDefs[i].cors.credentials`'
       ];
 
       if (conditionsArray.indexOf(false) !== -1) {


### PR DESCRIPTION
Implementing #36 

This Pull Request adds support for (optional) CORS configuration of the API.
Sane defaults are provided (in line with the WSO2 defaults if you enable CORS manually), so you can only supply your allowed origins for example as a minimal configuration, or specify all properties if desired.

- [x] Updated unit tests (`*.spec.js`)  
- [x] Updated e2e tests ([here](https://github.com/ramgrandhi/serverless-wso2-apim/tree/main/src/__tests__/e2e))  
- [x] Updated documentation ([here](https://github.com/ramgrandhi/serverless-wso2-apim/blob/main/README.md))   
