### PR TITLE
Bugfix: recursive resolveCfImportValue() fails

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -25,12 +25,12 @@ async function goToSleep(milliS) {
   return new Promise(resolve => setTimeout(resolve, milliS));
 }
 
-function resolveCfImportValue(provider, name) {
-  return provider.request('CloudFormation', 'listExports').then(result => {
+function resolveCfImportValue(provider, name, params = {}) {
+  return provider.request('CloudFormation', 'listExports', params).then(result => {
     const targetExportMeta = result.Exports.find(exportMeta => exportMeta.Name === name);
     if (targetExportMeta) return targetExportMeta.Value;
     if (result.NextToken) {
-      return resolveCfImportValue(name, { NextToken: result.NextToken });
+      return resolveCfImportValue(provider, name, { NextToken: result.NextToken });
     }
     return null;
   });

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -1,0 +1,53 @@
+const { resolveCfImportValue } = require('./utils');
+
+describe('resolveCfImportValue', () => {
+  let calls = 0;
+
+  const fakeExports = [
+    { Name: 'First', Value: 'A' },
+    { Name: 'Second', Value: 'B' },
+    { Name: 'Third', Value: 'C' },
+  ];
+
+  beforeEach(() => {
+    calls = 0;
+  });
+
+  const fakeProvider = {
+    request: async (service, method, params) => {
+      calls++;
+      if (service !== 'CloudFormation' && method !== 'listExports') {
+        throw new Error('Unexpected call to the fake provider.');
+      }
+      // Simulation page size of 2
+      // AWS will use a page size of 100
+      const start = (params && params.NextToken) || 0;
+      const end = start + 2;
+      return {
+        Exports: fakeExports.slice(start, end),
+        NextToken: end < fakeExports.length ? end : null,
+      };
+    },
+  };
+
+  it('value found on 1st page', async () => {
+    const val = await resolveCfImportValue(fakeProvider, 'First');
+
+    expect(val).toEqual('A');
+    expect(calls).toEqual(1);
+  });
+
+  it('value not found', async () => {
+    const val = await resolveCfImportValue(fakeProvider, 'Unknown');
+
+    expect(val).toBeNull();
+    expect(calls).toEqual(2);
+  });
+
+  it('value found on 2nd page', async () => {
+    const val = await resolveCfImportValue(fakeProvider, 'Third');
+
+    expect(val).toEqual('C');
+    expect(calls).toEqual(2);
+  });
+});


### PR DESCRIPTION
Hotfix for an issue that is triggered if the CF value you want to import is not on the 1st page returned by AWS. (First page returns 100 records)

The recursive call to `resolveCfImportValue()` did not use the right parameters, which led to the following error:

```
TypeError: provider.request is not a function
```

TODO:
- [ ] Testing