### PR TITLE
upsert swaggerspec after upsert of api definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Serverless Framework plugin to manage APIs on [WSO2 API Manager](https://wso2.co
 - Manage your API definitions via `sls info` and `sls remove`.
 - Supports `HTTP` and `JMS` backends with mediation policies & additional API properties.
 - Uploads backend certificates (including CAs) to enable HTTP/s connectivity with backends.
-- Supports `Swagger 2.0` and `OpenAPI 3.0` specifications.
+- Supports `Swagger 2.0` and `OpenAPI 3.0` specifications and will upload those to WSO2
 - Automatically detects the version of WSO2 API Manager running.
 
 ---

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -569,6 +569,41 @@ async function listCertInfo(wso2APIM, accessToken, certAlias) {
 }
 
 
+/**
+ * Upsert the swagger spec of the wso2 api
+ * see https://docs.wso2.com/display/AM260/apidocs/publisher/#!/operations#APIIndividual#apisApiIdSwaggerPut
+ * @param {*} wso2APIM 
+ * @param {*} accessToken 
+ * @param {*} apiId 
+ * @param {*} swaggerSpec 
+ * @returns 
+ */
+ async function upsertSwaggerSpec(wso2APIM, accessToken, apiId, swaggerSpec) {
+  try {
+    const url = `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/${apiId}/swagger`;
+    const config = {
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Content-Type': 'multipart/form-data'
+      },
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: false
+      })
+    };
+    
+    const data = new FormData();
+    data.append('apiDefinition', JSON.stringify(swaggerSpec));
+
+    return axios.put(url, data, config)
+      .then((_) => undefined); // eat the http response, not needed outside of this api layer
+  }
+  catch (err) {
+    utils.renderError(err);
+    throw err;
+  }
+}
+
+
 module.exports = {
   registerClient,
   generateToken,
@@ -584,4 +619,5 @@ module.exports = {
   updateAPIDef,
   removeAPIDef,
   listInvokableAPIUrl,
+  upsertSwaggerSpec,
 };

--- a/src/3.2.0/wso2apim.js
+++ b/src/3.2.0/wso2apim.js
@@ -510,7 +510,6 @@ async function removeAPIDef(wso2APIM, accessToken, apiId) {
   }
 }
 
-
 // Removes backend certificate
 async function removeCert(wso2APIM, accessToken, certAlias) {
   try {
@@ -606,6 +605,40 @@ async function listCertInfo(wso2APIM, accessToken, certAlias) {
   }
 }
 
+/**
+ * Upsert the swagger spec of the wso2 api
+ * see https://apim.docs.wso2.com/en/3.2.0/develop/product-apis/publisher-apis/publisher-v1/publisher-v1/#tag/APIs/paths/~1apis~1{apiId}~1swagger/put for documentation
+ * @param {*} wso2APIM 
+ * @param {*} accessToken 
+ * @param {*} apiId 
+ * @param {*} swaggerSpec 
+ * @returns 
+ */
+ async function upsertSwaggerSpec(wso2APIM, accessToken, apiId, swaggerSpec) {
+  try {
+    const url = `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/${apiId}/swagger`;
+    const config = {
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Content-Type': 'multipart/form-data'
+      },
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: false
+      })
+    };
+    
+    const data = new FormData();
+    data.append('apiDefinition', JSON.stringify(swaggerSpec));
+
+    return axios.put(url, data, config)
+      .then((_) => undefined); // eat the http response, not needed outside of this api layer
+  }
+  catch (err) {
+    utils.renderError(err);
+    throw err;
+  }
+}
+
 
 module.exports = {
   registerClient,
@@ -622,4 +655,5 @@ module.exports = {
   updateAPIDef,
   removeAPIDef,
   listInvokableAPIUrl,
+  upsertSwaggerSpec,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -617,6 +617,7 @@ class Serverless_WSO2_APIM {
       // Update API definitions, if they exist
       for (const [i, api] of this.cache.deploymentStatus.entries()) {
         try {
+          let apiId = api.apiId;
           //Update
           if (api.apiId !== undefined) {
             // this.serverless.cli.log(pluginNameSuffix + "Updating " + api.apiName + " (" + api.apiId + ")..");
@@ -638,15 +639,22 @@ class Serverless_WSO2_APIM {
           //Create
           else {
             // this.serverless.cli.log(pluginNameSuffix + "Creating " + api.apiName + "".."");
-            await wso2apim.createAPIDef(
+            const result = await wso2apim.createAPIDef(
               wso2APIM,
               this.cache.accessToken,
               apiDefs[i]
             );
+            apiId = result.apiId;
+
             this.serverless.cli.log(
               pluginNameSuffix + 'Creating ' + api.apiName + '.. OK'
             );
           }
+
+          // now update the swagger spec of the API
+          this.serverless.cli.log(`${pluginNameSuffix} Upserting Swagger spec for api ${api.apiName} (id=${apiId})`);
+          await wso2apim.upsertSwaggerSpec(wso2APIM, this.cache.accessToken, apiId, apiDefs[i].swaggerSpec);
+          this.serverless.cli.log(`${pluginNameSuffix} Upserting OK`);
         } catch (err) {
           this.serverless.cli.log(
             'Creating / Updating ' +


### PR DESCRIPTION
After creating/updating the api we now also PUT the swagger spec so it enriches the documentation of the API in WSO2

Fixes #80

🚨 Please review the [guidelines for contributing](https://github.com/ramgrandhi/serverless-wso2-apim/blob/main/CONTRIBUTING.md) to this repository.  

**<< Describe your change >>**

- [ ] Updated unit tests (`*.spec.js`)  
- [ ] Updated e2e tests ([here](https://github.com/ramgrandhi/serverless-wso2-apim/tree/main/src/__tests__/e2e))  
- [x] Updated documentation ([here](https://github.com/ramgrandhi/serverless-wso2-apim/blob/main/README.md))   

🙌 Thank you! 