### PR TITLE
Feat/Add `hangSecondsBeforeUpsertingSwagger` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ Serverless Framework plugin to manage APIs on [WSO2 API Manager](https://wso2.co
 >
 > <br>
 
+#### Why `hangSecondsBeforeUpsertingSwagger`?
+
+In some complex/distributed WSO2 setups it may take a while to synchronize the API definitions. When upserting the swagger right after the API def update, it will override the common data between them (e.g. CORS Headers) with the outdated API definitions.
+When that happens, adding a hang time in between helps updating both the API definitions & the swagger successfully.
+
 > ### **`custom.wso2apim.apidefs.<Your-API>.*`**
 >
 > | Parameter                                 | What?                                                                                                                                                                                                                                                                                                                       |                                                                               Usage Example |

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Serverless Framework plugin to manage APIs on [WSO2 API Manager](https://wso2.co
 > | `user`       | Username with an optional tenant symbol.                                                                                              |            `user@tenant` |
 > | `pass`       | Password, supports [Serverless Variables](https://www.serverless.com/framework/docs/providers/aws/guide/variables/) syntax.           |                    `xxx` |
 > | `gatewayEnv` | Target gateway environment, as configured in your WSO2 installation.                                                                  | `Production and Sandbox` |
+> | `hangTimeBeforeUpsertingSwagger` | The time in seconds to wait before upserting the swagger specs                                                    |                     `30` |
 >
 > <br>
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Serverless Framework plugin to manage APIs on [WSO2 API Manager](https://wso2.co
 > | `user`       | Username with an optional tenant symbol.                                                                                              |            `user@tenant` |
 > | `pass`       | Password, supports [Serverless Variables](https://www.serverless.com/framework/docs/providers/aws/guide/variables/) syntax.           |                    `xxx` |
 > | `gatewayEnv` | Target gateway environment, as configured in your WSO2 installation.                                                                  | `Production and Sandbox` |
-> | `hangTimeBeforeUpsertingSwagger` | The time in seconds to wait before upserting the swagger specs                                                    |                     `30` |
+> | `hangSecondsBeforeUpsertingSwagger` | The time in seconds to wait before upserting the swagger specs (Optional)                                      |                     `30` |
 >
 > <br>
 

--- a/src/__tests__/e2e/invalid-hangSecondsBeforeUpsertingSwagger-negative-number/serverless.yml
+++ b/src/__tests__/e2e/invalid-hangSecondsBeforeUpsertingSwagger-negative-number/serverless.yml
@@ -1,0 +1,57 @@
+service: serverless-wso2-apim
+provider:
+  name: aws
+  stackName: ${env:STACK_NAME}
+  deploymentBucket:
+    name: ${env:TEST_ID_NORMALIZED}
+plugins:
+  - serverless-localstack
+  - serverless-deployment-bucket
+  - '../../../../src'
+
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ Modify the configuration below to suit your test case.
+#⬇⬇⬇ START HERE ⬇⬇⬇⬇ Help: https://github.com/ramgrandhi/serverless-wso2-apim#configuration-reference
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ For a full list of env vars that you can use, refer `src/__tests__/e2e/e2e.test.js`
+custom:
+  wso2apim:
+    enabled: true
+    host: ${env:WSO2_HOST}
+    port: ${env:WSO2_PORT}
+    user: ${env:WSO2_USER}
+    pass: ${env:WSO2_PASS}
+    gatewayEnv: ${env:WSO2_ENV}
+    hangSecondsBeforeUpsertingSwagger: -1
+    apidefs:
+      - name: ${env:TEST_ID}-1
+        description: ${env:TEST_ID}-1
+        rootContext: /${env:TEST_ID}-1
+        version: '1'
+        visibility: 'PUBLIC'
+        backend:
+          http:
+            baseUrl: 'https://baseUrl'
+        maxTps: 10
+        tags:
+          - ${env:TEST_ID}-1
+        swaggerSpec:
+          openapi: 3.0.0
+          info:
+            title: ${env:TEST_ID}-1
+            version: '1'
+            contact:
+              name: ${env:TEST_ID}-1
+              email: ${env:TEST_ID}-1
+          paths:
+            /*:
+              post:
+                responses:
+                  '201':
+                    description: Created
+                x-auth-type: 'None'
+
+# Optionally, add your other AWS provider-specific resources below.
+# Make sure there is at least one resource listed below, otherwise stack deployment would fail.
+resources:
+  Resources:
+    Topic:
+      Type: AWS::SNS::Topic

--- a/src/__tests__/e2e/invalid-hangSecondsBeforeUpsertingSwagger-string/serverless.yml
+++ b/src/__tests__/e2e/invalid-hangSecondsBeforeUpsertingSwagger-string/serverless.yml
@@ -1,0 +1,57 @@
+service: serverless-wso2-apim
+provider:
+  name: aws
+  stackName: ${env:STACK_NAME}
+  deploymentBucket:
+    name: ${env:TEST_ID_NORMALIZED}
+plugins:
+  - serverless-localstack
+  - serverless-deployment-bucket
+  - '../../../../src'
+
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ Modify the configuration below to suit your test case.
+#⬇⬇⬇ START HERE ⬇⬇⬇⬇ Help: https://github.com/ramgrandhi/serverless-wso2-apim#configuration-reference
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ For a full list of env vars that you can use, refer `src/__tests__/e2e/e2e.test.js`
+custom:
+  wso2apim:
+    enabled: true
+    host: ${env:WSO2_HOST}
+    port: ${env:WSO2_PORT}
+    user: ${env:WSO2_USER}
+    pass: ${env:WSO2_PASS}
+    gatewayEnv: ${env:WSO2_ENV}
+    hangSecondsBeforeUpsertingSwagger: 'not a number'
+    apidefs:
+      - name: ${env:TEST_ID}-1
+        description: ${env:TEST_ID}-1
+        rootContext: /${env:TEST_ID}-1
+        version: '1'
+        visibility: 'PUBLIC'
+        backend:
+          http:
+            baseUrl: 'https://baseUrl'
+        maxTps: 10
+        tags:
+          - ${env:TEST_ID}-1
+        swaggerSpec:
+          openapi: 3.0.0
+          info:
+            title: ${env:TEST_ID}-1
+            version: '1'
+            contact:
+              name: ${env:TEST_ID}-1
+              email: ${env:TEST_ID}-1
+          paths:
+            /*:
+              post:
+                responses:
+                  '201':
+                    description: Created
+                x-auth-type: 'None'
+
+# Optionally, add your other AWS provider-specific resources below.
+# Make sure there is at least one resource listed below, otherwise stack deployment would fail.
+resources:
+  Resources:
+    Topic:
+      Type: AWS::SNS::Topic

--- a/src/__tests__/e2e/valid-hangSecondsBeforeUpsertingSwagger-option/serverless.yml
+++ b/src/__tests__/e2e/valid-hangSecondsBeforeUpsertingSwagger-option/serverless.yml
@@ -1,0 +1,57 @@
+service: serverless-wso2-apim
+provider:
+  name: aws
+  stackName: ${env:STACK_NAME}
+  deploymentBucket:
+    name: ${env:TEST_ID_NORMALIZED}
+plugins:
+  - serverless-localstack
+  - serverless-deployment-bucket
+  - '../../../../src'
+
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ Modify the configuration below to suit your test case.
+#⬇⬇⬇ START HERE ⬇⬇⬇⬇ Help: https://github.com/ramgrandhi/serverless-wso2-apim#configuration-reference
+#⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇⬇ For a full list of env vars that you can use, refer `src/__tests__/e2e/e2e.test.js`
+custom:
+  wso2apim:
+    enabled: true
+    host: ${env:WSO2_HOST}
+    port: ${env:WSO2_PORT}
+    user: ${env:WSO2_USER}
+    pass: ${env:WSO2_PASS}
+    gatewayEnv: ${env:WSO2_ENV}
+    hangSecondsBeforeUpsertingSwagger: 1
+    apidefs:
+      - name: ${env:TEST_ID}-1
+        description: ${env:TEST_ID}-1
+        rootContext: /${env:TEST_ID}-1
+        version: '1'
+        visibility: 'PUBLIC'
+        backend:
+          http:
+            baseUrl: 'https://baseUrl'
+        maxTps: 10
+        tags:
+          - ${env:TEST_ID}-1
+        swaggerSpec:
+          openapi: 3.0.0
+          info:
+            title: ${env:TEST_ID}-1
+            version: '1'
+            contact:
+              name: ${env:TEST_ID}-1
+              email: ${env:TEST_ID}-1
+          paths:
+            /*:
+              post:
+                responses:
+                  '201':
+                    description: Created
+                x-auth-type: 'None'
+
+# Optionally, add your other AWS provider-specific resources below.
+# Make sure there is at least one resource listed below, otherwise stack deployment would fail.
+resources:
+  Resources:
+    Topic:
+      Type: AWS::SNS::Topic

--- a/src/index.js
+++ b/src/index.js
@@ -817,7 +817,7 @@ class Serverless_WSO2_APIM {
             this.serverless.cli.log(
               `${pluginNameSuffix}Hanging for ${wso2APIM.hangSecondsBeforeUpsertingSwagger}s before upserting swagger ${api.apiName}..`
             );
-            utils.goToSleep(wso2APIM.hangSecondsBeforeUpsertingSwagger * 1000);
+            await utils.goToSleep(wso2APIM.hangSecondsBeforeUpsertingSwagger * 1000);
           }
 
           // now update the swagger spec of the API

--- a/src/index.js
+++ b/src/index.js
@@ -173,8 +173,8 @@ class Serverless_WSO2_APIM {
         ((wso2APIM.user) && (wso2APIM.user.length > 0)),
         ((wso2APIM.pass) && (wso2APIM.pass.length > 0)),
         ((wso2APIM.gatewayEnv) && (wso2APIM.gatewayEnv.length > 0)),
-        wso2APIM.hangTimeBeforeUpsertingSwagger
-          ? ((typeof wso2APIM.hangTimeBeforeUpsertingSwagger === 'number') && (wso2APIM.hangTimeBeforeUpsertingSwagger > 0))
+        wso2APIM.hangSecondsBeforeUpsertingSwagger
+          ? ((typeof wso2APIM.hangSecondsBeforeUpsertingSwagger === 'number') && (wso2APIM.hangSecondsBeforeUpsertingSwagger > 0))
           : true,
         (wso2APIM.apidefs.length > 0),
         (wso2APIM.apidefs.every(def => typeof def.cors === 'undefined' ||
@@ -207,7 +207,7 @@ class Serverless_WSO2_APIM {
         'Invalid value assigned to `custom.wso2apim.user`',
         'Invalid value assigned to `custom.wso2apim.pass`',
         'Invalid value assigned to `custom.wso2apim.gatewayEnv`',
-        'Invalid value assigned to `custom.wso2apim.hangTimeBeforeUpsertingSwagger`',
+        'Invalid value assigned to `custom.wso2apim.hangSecondsBeforeUpsertingSwagger`',
         'No API definitions supplied `custom.wso2apim.apidefs`',
         'Invalid value assigned to `custom.wso2apim.apiDefs[i].cors.credentials`',
         'Invalid value assigned to `custom.wso2apim.subscriberVisibility`',
@@ -813,11 +813,11 @@ class Serverless_WSO2_APIM {
             );
           }
 
-          if (wso2APIM.hangTimeBeforeUpsertingSwagger) {
+          if (wso2APIM.hangSecondsBeforeUpsertingSwagger) {
             this.serverless.cli.log(
-              `${pluginNameSuffix}Hanging for ${wso2APIM.hangTimeBeforeUpsertingSwagger}s before upserting swagger ${api.apiName}..`
+              `${pluginNameSuffix}Hanging for ${wso2APIM.hangSecondsBeforeUpsertingSwagger}s before upserting swagger ${api.apiName}..`
             );
-            utils.goToSleep(wso2APIM.hangTimeBeforeUpsertingSwagger * 1000);
+            utils.goToSleep(wso2APIM.hangSecondsBeforeUpsertingSwagger * 1000);
           }
 
           // now update the swagger spec of the API

--- a/src/index.js
+++ b/src/index.js
@@ -814,7 +814,9 @@ class Serverless_WSO2_APIM {
           }
 
           if (wso2APIM.hangTimeBeforeUpsertingSwagger) {
-            this.serverless.cli.log(`${pluginNameSuffix}Hanging for 30s before upserting swagger ${api.apiName}..`);
+            this.serverless.cli.log(
+              `${pluginNameSuffix}Hanging for ${wso2APIM.hangTimeBeforeUpsertingSwagger}s before upserting swagger ${api.apiName}..`
+            );
             utils.goToSleep(wso2APIM.hangTimeBeforeUpsertingSwagger * 1000);
           }
 

--- a/src/index.js
+++ b/src/index.js
@@ -173,6 +173,9 @@ class Serverless_WSO2_APIM {
         ((wso2APIM.user) && (wso2APIM.user.length > 0)),
         ((wso2APIM.pass) && (wso2APIM.pass.length > 0)),
         ((wso2APIM.gatewayEnv) && (wso2APIM.gatewayEnv.length > 0)),
+        wso2APIM.hangTimeBeforeUpsertingSwagger
+          ? ((typeof wso2APIM.hangTimeBeforeUpsertingSwagger === 'number') && (wso2APIM.hangTimeBeforeUpsertingSwagger > 0))
+          : true,
         (wso2APIM.apidefs.length > 0),
         (wso2APIM.apidefs.every(def => typeof def.cors === 'undefined' ||
           (typeof def.cors.credentials === 'undefined' || typeof def.cors.credentials === 'boolean'))
@@ -204,6 +207,7 @@ class Serverless_WSO2_APIM {
         'Invalid value assigned to `custom.wso2apim.user`',
         'Invalid value assigned to `custom.wso2apim.pass`',
         'Invalid value assigned to `custom.wso2apim.gatewayEnv`',
+        'Invalid value assigned to `custom.wso2apim.hangTimeBeforeUpsertingSwagger`',
         'No API definitions supplied `custom.wso2apim.apidefs`',
         'Invalid value assigned to `custom.wso2apim.apiDefs[i].cors.credentials`',
         'Invalid value assigned to `custom.wso2apim.subscriberVisibility`',
@@ -807,6 +811,11 @@ class Serverless_WSO2_APIM {
             this.serverless.cli.log(
               pluginNameSuffix + 'Creating ' + api.apiName + '.. OK'
             );
+          }
+
+          if (wso2APIM.hangTimeBeforeUpsertingSwagger) {
+            this.serverless.cli.log(`${pluginNameSuffix}Hanging for 30s before upserting swagger ${api.apiName}..`);
+            utils.goToSleep(wso2APIM.hangTimeBeforeUpsertingSwagger * 1000);
           }
 
           // now update the swagger spec of the API


### PR DESCRIPTION
🚨 Please review the [guidelines for contributing](https://github.com/ramgrandhi/serverless-wso2-apim/blob/main/CONTRIBUTING.md) to this repository.  

**Adds the `hangSecondsBeforeUpsertingSwagger` option to hang before upserting WSO2 swagger**

In some complex/distributed WSO2 setups it may take a while to synchronize the API definitions. When upserting the swagger right after the API def update, it will override the common data between them (e.g. CORS Headers) with the outdated API definitions.
When that happens, adding a hang time in between helps updating both the API definitions & the swagger successfully.

It fixes #99  

- [ ] Updated unit tests (`*.spec.js`)  
- [X] Updated e2e tests ([here](https://github.com/ramgrandhi/serverless-wso2-apim/tree/main/src/__tests__/e2e))  
- [X] Updated documentation ([here](https://github.com/ramgrandhi/serverless-wso2-apim/blob/main/README.md))   

🙌 Thank you! 