### PR TITLE
fix: use supported version 1 for api operations apart from DCR api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const versionSlugsSupported = {
     'versionSlug': 'v0.14'
   },
   '3.2.0': {
-    'versionSlug': 'v1.2'
+    'versionSlug': 'v1'
   }
 };
 


### PR DESCRIPTION
Use supported version 1 for api operations apart from DCR api for API WSO2 version 3.2

**<< Describe your change >>**

- [ ] Updated unit tests (`*.spec.js`)  
- [ ] Updated e2e tests ([here](https://github.com/ramgrandhi/serverless-wso2-apim/tree/main/src/__tests__/e2e))  
- [ ] Updated documentation ([here](https://github.com/ramgrandhi/serverless-wso2-apim/blob/main/README.md))   

🙌 Thank you! 