### PR TITLE
Feat/Retry updating WSO2 api definitions while it is outdated

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "jest e2e --verbose",
     "test:e2e:destroy": "yarn stop:wso2-2.6.0 && yarn stop:wso2-3.2.0 && yarn stop:localstack",
     "test": "yarn test:unit",
+    "test:watch": "yarn test --watch",
     "start:wso2-2.6.0": "docker run --name api-manager-260 -p 127.0.0.1:8260:8243 -p 127.0.0.1:9260:9443 --rm wso2/wso2am:2.6.0",
     "start:wso2-3.2.0": "docker run --name api-manager-320 -p 127.0.0.1:8320:8243 -p 127.0.0.1:9320:9443 --rm wso2/wso2am:3.2.0",
     "start:localstack": "docker run --name localstack -p 127.0.0.1:4566:4566 -p 127.0.0.1:4571:4571 --rm localstack/localstack:1.4",
@@ -67,6 +68,9 @@
   },
   "jest": {
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "watchPathIgnorePatterns": [
+      "<rootDir>/jest.json"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,23 +42,18 @@
     "serverless"
   ],
   "devDependencies": {
-    "axios": "^1.6.3",
     "babel-eslint": "^10.1.0",
     "chalk": "^4.1.0",
     "codecov": "^3.8.1",
     "concurrently": "^6.0.0",
     "eslint": "^7.20.0",
     "eslint-plugin-jest": "^24.1.5",
-    "form-data": "^4.0.0",
-    "fs": "^0.0.2",
     "https": "^1.0.0",
     "jest": "^26.6.3",
-    "qs": "^6.11.2",
     "release": "^6.3.0",
     "serverless": "^1.75.1",
     "serverless-deployment-bucket": "^1.4.1",
-    "serverless-localstack": "^0.4.30",
-    "split-ca": "^1.0.1"
+    "serverless-localstack": "^0.4.30"
   },
   "dependencies": {
     "axios": "^1.6.3",

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -609,7 +609,7 @@ async function upsertSwaggerSpec(wso2APIM, accessToken, apiId, swaggerSpec) {
     data.append('apiDefinition', JSON.stringify(swaggerSpec));
 
     return axios.put(url, data, config)
-      .then((_) => undefined); // eat the http response, not needed outside of this api layer
+      .then(() => undefined); // eat the http response, not needed outside of this api layer
   }
   catch (err) {
     utils.renderError(err);

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -617,6 +617,33 @@ async function upsertSwaggerSpec(wso2APIM, accessToken, apiId, swaggerSpec) {
   }
 }
 
+/**
+ * Retrieves the API Definition saved at the WSO2 platform
+ *
+ * @param {*} wso2APIM
+ * @param {string} accessToken
+ * @param {string} apiId
+ * @returns {*}
+ */
+async function getApiDef(wso2APIM, accessToken, apiId) {
+  const url = `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/${apiId}`;
+
+  try {
+    const result = await axios.get(url, {
+      headers: {
+        'Authorization': 'Bearer ' + accessToken
+      },
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: false
+      })
+    });
+
+    return result.data;
+  } catch (err) {
+    utils.renderError(err);
+    throw err;
+  }
+}
 
 module.exports = {
   registerClient,
@@ -634,4 +661,5 @@ module.exports = {
   removeAPIDef,
   listInvokableAPIUrl,
   upsertSwaggerSpec,
+  getApiDef,
 };

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -652,10 +652,14 @@ async function getApiDef(wso2APIM, accessToken, apiId) {
  * @param {string} accessToken
  * @param {string} apiId
  * @param {Object} apiDef
- * @returns {boolean}
+ * @returns {Promise<boolean>}
  */
 async function checkApiDefIsUpdated(wso2APIM, accessToken, apiId, apiDef) {
   const newApiDef = constructAPIDef(wso2APIM.user, wso2APIM.gatewayEnv, apiDef, apiId);
+
+  // ? When no cors configuration is set, it applies the default one from wso2
+  if (!newApiDef.corsConfiguration) return true;
+
   const currentApiDef = await getApiDef(wso2APIM, accessToken, apiId);
 
   // TODO: We should test for any intersection data between api definition and swagger specs

--- a/src/2.6.0/wso2apim.js
+++ b/src/2.6.0/wso2apim.js
@@ -645,6 +645,23 @@ async function getApiDef(wso2APIM, accessToken, apiId) {
   }
 }
 
+/**
+ * Check if the API def is up to date
+ *
+ * @param {*} wso2APIM
+ * @param {string} accessToken
+ * @param {string} apiId
+ * @param {Object} apiDef
+ * @returns {boolean}
+ */
+async function checkApiDefIsUpdated(wso2APIM, accessToken, apiId, apiDef) {
+  const newApiDef = constructAPIDef(wso2APIM.user, wso2APIM.gatewayEnv, apiDef, apiId);
+  const currentApiDef = await getApiDef(wso2APIM, accessToken, apiId);
+
+  // TODO: We should test for any intersection data between api definition and swagger specs
+  return utils.isEqual(newApiDef.corsConfiguration, currentApiDef.corsConfiguration);
+}
+
 module.exports = {
   registerClient,
   generateToken,
@@ -662,4 +679,5 @@ module.exports = {
   listInvokableAPIUrl,
   upsertSwaggerSpec,
   getApiDef,
+  checkApiDefIsUpdated,
 };

--- a/src/2.6.0/wso2apim.spec.js
+++ b/src/2.6.0/wso2apim.spec.js
@@ -58,6 +58,18 @@ const wso2APIM = {
 };
 const apiId = '123456789';
 
+const baseUrl = `https://${wso2APIM.host}:${wso2APIM.port}`;
+const publisherBaseUrl = `${baseUrl}/api/am/publisher/${wso2APIM.versionSlug}`;
+const storeBaseUrl = `${baseUrl}/api/am/store/${wso2APIM.versionSlug}`;
+
+const defaultFaulty = {
+  response: {
+    data: { message: 'failed' },
+    status: 500,
+    headers: {},
+  },
+};
+
 describe('wso2apim-2.6.0', () => {
   describe('registerClient()', () => {
     it('should handle a successful response', async () => {
@@ -73,7 +85,7 @@ describe('wso2apim-2.6.0', () => {
       const response = await registerClient(wso2APIM);
 
       expect(axios.post).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/client-registration/${wso2APIM.versionSlug}/register`,
+        `${baseUrl}/client-registration/${wso2APIM.versionSlug}/register`,
         {
           clientName: 'serverless-wso2-apim',
           grantType: 'password refresh_token',
@@ -90,9 +102,9 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() => Promise.reject());
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(registerClient(wso2APIM)).rejects.toThrow();
+      await expect(registerClient(wso2APIM)).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -109,7 +121,7 @@ describe('wso2apim-2.6.0', () => {
       const response = await generateToken(wso2APIM, 'foo123', 'xxxyyyzzz');
 
       expect(axios.post).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/oauth2/token`,
+        `${baseUrl}/oauth2/token`,
         qs.stringify({
           grant_type: 'password',
           username: wso2APIM.user,
@@ -126,9 +138,9 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() => Promise.reject());
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(generateToken(wso2APIM, 'foo123', 'xxxyyyzzz')).rejects.toThrow();
+      await expect(generateToken(wso2APIM, 'foo123', 'xxxyyyzzz')).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -143,7 +155,7 @@ describe('wso2apim-2.6.0', () => {
       );
 
       expect(axios.get).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis?query=name:${wso2APIM.apidefs[0].name} version:${wso2APIM.apidefs[0].version} context:${wso2APIM.apidefs[0].rootContext}`,
+        `${publisherBaseUrl}/apis?query=name:${wso2APIM.apidefs[0].name} version:${wso2APIM.apidefs[0].version} context:${wso2APIM.apidefs[0].rootContext}`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -155,9 +167,9 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.get.mockImplementationOnce(() => Promise.reject());
+      axios.get.mockRejectedValueOnce(defaultFaulty);
 
-      expect(
+      await expect(
         isAPIDeployed(
           wso2APIM,
           'xxx',
@@ -165,7 +177,7 @@ describe('wso2apim-2.6.0', () => {
           wso2APIM.apidefs[0].version,
           wso2APIM.apidefs[0].rootContext
         )
-      ).rejects.toThrow();
+      ).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -174,7 +186,7 @@ describe('wso2apim-2.6.0', () => {
       const response = await isCertUploaded(wso2APIM, 'xxx', 'alias');
 
       expect(axios.get).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/certificates/alias`,
+        `${publisherBaseUrl}/certificates/alias`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -186,9 +198,9 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.get.mockImplementationOnce(() => Promise.reject());
+      axios.get.mockRejectedValueOnce(defaultFaulty);
 
-      expect(isCertUploaded(wso2APIM, 'xxx', 'alias')).rejects.toThrow();
+      await expect(isCertUploaded(wso2APIM, 'xxx', 'alias')).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -208,7 +220,7 @@ describe('wso2apim-2.6.0', () => {
       const response = await createAPIDef(wso2APIM, 'xxx', wso2APIM.apidefs[0]);
 
       expect(axios.post).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis`,
+        `${publisherBaseUrl}/apis`,
         expect.objectContaining({}),
         {
           headers: {
@@ -228,11 +240,11 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() => Promise.reject());
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(
+      await expect(
         createAPIDef(wso2APIM, 'xxx', wso2APIM.apidefs[0])
-      ).rejects.toThrow();
+      ).rejects.toBeUndefined();
     });
   });
 
@@ -241,7 +253,7 @@ describe('wso2apim-2.6.0', () => {
       const response = await publishAPIDef(wso2APIM, 'xxx', apiId);
 
       expect(axios.post).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/change-lifecycle`,
+        `${publisherBaseUrl}/apis/change-lifecycle`,
         expect.objectContaining({}),
         {
           headers: {
@@ -259,9 +271,9 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() => Promise.reject());
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(publishAPIDef(wso2APIM, 'xxx', apiId)).rejects.toThrow();
+      await expect(publishAPIDef(wso2APIM, 'xxx', apiId)).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -270,7 +282,7 @@ describe('wso2apim-2.6.0', () => {
       const response = await listInvokableAPIUrl(wso2APIM, 'xxx', apiId);
 
       expect(axios.get).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/store/${wso2APIM.versionSlug}/apis/${apiId}`,
+        `${storeBaseUrl}/apis/${apiId}`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -283,9 +295,9 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.get.mockImplementationOnce(() => Promise.reject());
+      axios.get.mockRejectedValueOnce(defaultFaulty);
 
-      expect(listInvokableAPIUrl(wso2APIM, 'xxx', apiId)).rejects.toThrow();
+      await expect(listInvokableAPIUrl(wso2APIM, 'xxx', apiId)).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -303,9 +315,9 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() => Promise.reject());
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(
+      await expect(
         uploadCert(
           wso2APIM,
           'xxx',
@@ -313,7 +325,7 @@ describe('wso2apim-2.6.0', () => {
           wso2APIM.apidefs[0].backend.http.certChain,
           wso2APIM.apidefs[0].backend.http.baseUrl
         )
-      ).rejects.toThrow();
+      ).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -327,7 +339,7 @@ describe('wso2apim-2.6.0', () => {
       );
 
       expect(axios.put).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/${apiId}`,
+        `${publisherBaseUrl}/apis/${apiId}`,
         expect.objectContaining({}),
         {
           headers: {
@@ -341,11 +353,11 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.put.mockImplementationOnce(() => Promise.reject());
+      axios.put.mockRejectedValueOnce(defaultFaulty);
 
-      expect(
+      await expect(
         updateAPIDef(wso2APIM, 'xxx', wso2APIM.apidefs[0], apiId)
-      ).rejects.toThrow();
+      ).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -354,7 +366,7 @@ describe('wso2apim-2.6.0', () => {
       const response = await removeAPIDef(wso2APIM, 'xxx', apiId);
 
       expect(axios.delete).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/${apiId}`,
+        `${publisherBaseUrl}/apis/${apiId}`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -366,9 +378,9 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.delete.mockImplementationOnce(() => Promise.reject());
+      axios.delete.mockRejectedValueOnce(defaultFaulty);
 
-      expect(removeAPIDef(wso2APIM, 'xxx', apiId)).rejects.toThrow();
+      await expect(removeAPIDef(wso2APIM, 'xxx', apiId)).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -377,7 +389,7 @@ describe('wso2apim-2.6.0', () => {
       const response = await removeCert(wso2APIM, 'xxx', 'alias');
 
       expect(axios.delete).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/certificates/alias`,
+        `${publisherBaseUrl}/certificates/alias`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -389,9 +401,9 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.delete.mockImplementationOnce(() => Promise.reject());
+      axios.delete.mockRejectedValueOnce(defaultFaulty);
 
-      expect(removeCert(wso2APIM, 'xxx', 'alias')).rejects.toThrow();
+      await expect(removeCert(wso2APIM, 'xxx', 'alias')).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -405,7 +417,7 @@ describe('wso2apim-2.6.0', () => {
       );
 
       expect(axios.put).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/certificates/alias`,
+        `${publisherBaseUrl}/certificates/alias`,
         expect.objectContaining({}),
         {
           headers: {
@@ -419,16 +431,16 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.put.mockImplementationOnce(() => Promise.reject());
+      axios.put.mockRejectedValueOnce(defaultFaulty);
 
-      expect(
+      await expect(
         updateCert(
           wso2APIM,
           'xxx',
           'alias',
           wso2APIM.apidefs[0].backend.http.certChain
         )
-      ).rejects.toThrow();
+      ).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -437,7 +449,7 @@ describe('wso2apim-2.6.0', () => {
       const response = await listCertInfo(wso2APIM, 'xxx', 'alias');
 
       expect(axios.get).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/certificates/alias`,
+        `${publisherBaseUrl}/certificates/alias`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -451,18 +463,18 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.get.mockImplementationOnce(() => Promise.reject());
+      axios.get.mockRejectedValueOnce(defaultFaulty);
 
-      expect(listCertInfo(wso2APIM, 'xxx', 'alias')).rejects.toThrow();
+      await expect(listCertInfo(wso2APIM, 'xxx', 'alias')).rejects.toEqual(defaultFaulty);
     });
   });
 
   describe('upsertSwaggerSpec()', () => {
     it('should handle a successful response', async () => {
-      const response = await upsertSwaggerSpec(wso2APIM, 'xxx', 'id001', wso2APIM.apidefs[0].swaggerSpec);
+      await upsertSwaggerSpec(wso2APIM, 'xxx', 'id001', wso2APIM.apidefs[0].swaggerSpec);
 
       expect(axios.put).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/id001/swagger`,
+        `${publisherBaseUrl}/apis/id001/swagger`,
         expect.objectContaining({}),
         {
           headers: {
@@ -475,8 +487,8 @@ describe('wso2apim-2.6.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.put.mockImplementationOnce(() => Promise.reject());
-      expect(upsertSwaggerSpec(wso2APIM, 'xxx', 'id001', wso2APIM.apidefs[0].swaggerSpec)).rejects.toThrow();
+      axios.put.mockRejectedValueOnce(defaultFaulty);
+      await expect(upsertSwaggerSpec(wso2APIM, 'xxx', 'id001', wso2APIM.apidefs[0].swaggerSpec)).rejects.toEqual(defaultFaulty);
     });
   });
 

--- a/src/2.6.0/wso2apim.spec.js
+++ b/src/2.6.0/wso2apim.spec.js
@@ -687,13 +687,7 @@ describe('wso2apim-2.6.0', () => {
         {
           ...wso2APIM.apidefs[0],
           cors: {
-            headers: [
-              'Authorization',
-              'Access-Control-Allow-Origin',
-              'Content-Type',
-              'SOAPAction',
-              'x-custom-header',
-            ],
+            headers: corsConfiguration.accessControlAllowHeaders,
           },
         },
       ],

--- a/src/2.6.0/wso2apim.spec.js
+++ b/src/2.6.0/wso2apim.spec.js
@@ -728,5 +728,12 @@ describe('wso2apim-2.6.0', () => {
       const response = await checkApiDefIsUpdated(wso2APIM, 'xxx', 'alias', config.apidefs[0]);
       expect(response).toBeFalsy();
     });
+
+    it('should return truthy when the there is no cors configuration', async () => {
+      const response = await checkApiDefIsUpdated(wso2APIM, 'xxx', 'alias', wso2APIM.apidefs[0]);
+
+      expect(response).toBeTruthy();
+      expect(axios.get).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/2.6.0/wso2apim.spec.js
+++ b/src/2.6.0/wso2apim.spec.js
@@ -14,6 +14,7 @@ const {
   updateAPIDef,
   removeAPIDef,
   listInvokableAPIUrl,
+  getApiDef,
 } = require('./wso2apim');
 const axios = require('axios');
 const qs = require('qs');
@@ -630,6 +631,28 @@ describe('wso2apim-2.6.0', () => {
         technicalOwner: undefined,
         businessOwner: undefined,
       });
+    });
+  });
+
+  describe('getApiDef()', () => {
+    it('should handle a successful response', async () => {
+      const response = await getApiDef(wso2APIM, 'xxx', 'alias');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        `${publisherBaseUrl}/apis/alias`,
+        {
+          headers: {
+            Authorization: 'Bearer xxx',
+          },
+          httpsAgent: expect.objectContaining({}),
+        }
+      );
+      expect(response).toEqual('foo');
+    });
+
+    it('should handle a faulty response', async () => {
+      axios.get.mockRejectedValueOnce(defaultFaulty);
+      await expect(getApiDef(wso2APIM, 'xxx', 'alias')).rejects.toEqual(defaultFaulty);
     });
   });
 });

--- a/src/2.6.0/wso2apim.spec.js
+++ b/src/2.6.0/wso2apim.spec.js
@@ -15,6 +15,7 @@ const {
   removeAPIDef,
   listInvokableAPIUrl,
   getApiDef,
+  checkApiDefIsUpdated,
 } = require('./wso2apim');
 const axios = require('axios');
 const qs = require('qs');
@@ -653,6 +654,79 @@ describe('wso2apim-2.6.0', () => {
     it('should handle a faulty response', async () => {
       axios.get.mockRejectedValueOnce(defaultFaulty);
       await expect(getApiDef(wso2APIM, 'xxx', 'alias')).rejects.toEqual(defaultFaulty);
+    });
+  });
+
+  describe('checkApiDefIsUpdated()', () => {
+    const corsConfiguration = {
+      corsConfigurationEnabled: true,
+      accessControlAllowOrigins: [
+        '*'
+      ],
+      accessControlAllowCredentials: false,
+      accessControlAllowHeaders: [
+        'Authorization',
+        'Access-Control-Allow-Origin',
+        'Content-Type',
+        'SOAPAction',
+        'x-custom-header',
+      ],
+      accessControlAllowMethods: [
+        'GET',
+        'PUT',
+        'POST',
+        'DELETE',
+        'PATCH',
+        'OPTIONS'
+      ]
+    };
+
+    const config = {
+      ...wso2APIM,
+      apidefs: [
+        {
+          ...wso2APIM.apidefs[0],
+          cors: {
+            headers: [
+              'Authorization',
+              'Access-Control-Allow-Origin',
+              'Content-Type',
+              'SOAPAction',
+              'x-custom-header',
+            ],
+          },
+        },
+      ],
+    };
+
+    it('should return truthy when the apidef is updated', async () => {
+      axios.get.mockResolvedValueOnce({
+        data: {
+          ...config.apidefs[0],
+          corsConfiguration,
+        }
+      });
+
+      const response = await checkApiDefIsUpdated(wso2APIM, 'xxx', 'alias', config.apidefs[0]);
+      expect(response).toBeTruthy();
+    });
+
+    it('should return falsy when the apidef is outdated', async () => {
+      axios.get.mockResolvedValueOnce({
+        data: {
+          ...config.apidefs[0],
+          corsConfiguration: {
+            ...corsConfiguration,
+            accessControlAllowHeaders: [
+              ...corsConfiguration.accessControlAllowHeaders,
+              'x-new-custom-header',
+            ],
+          },
+        }
+      });
+
+      const response = await checkApiDefIsUpdated(wso2APIM, 'xxx', 'alias', config.apidefs[0]);
+      expect(response).toBeFalsy();
     });
   });
 });

--- a/src/3.2.0/wso2apim.js
+++ b/src/3.2.0/wso2apim.js
@@ -769,7 +769,7 @@ async function removeClientCert(wso2APIM, accessToken, certAlias, apiId) {
  * @param {*} swaggerSpec
  * @returns
  */
- async function upsertSwaggerSpec(wso2APIM, accessToken, apiId, swaggerSpec) {
+async function upsertSwaggerSpec(wso2APIM, accessToken, apiId, swaggerSpec) {
   try {
     const url = `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/${apiId}/swagger`;
     const config = {
@@ -786,8 +786,9 @@ async function removeClientCert(wso2APIM, accessToken, certAlias, apiId) {
     data.append('apiDefinition', JSON.stringify(swaggerSpec));
 
     return axios.put(url, data, config)
-      .then((_) => undefined).catch((err) => {
+      .then(() => undefined).catch((err) => {
         utils.renderError(err);
+        throw err;
       }); // eat the http response, not needed outside of this api layer
   }
   catch (err) {

--- a/src/3.2.0/wso2apim.js
+++ b/src/3.2.0/wso2apim.js
@@ -835,8 +835,13 @@ async function getApiDef(wso2APIM, accessToken, apiId) {
  * @returns {Promise<boolean>}
  */
 async function checkApiDefIsUpdated(wso2APIM, accessToken, apiId, apiDef) {
-  const newApiDef = await constructAPIDef(wso2APIM.user, wso2APIM.gatewayEnv, apiDef, apiId);
-  const currentApiDef = await getApiDef(wso2APIM, accessToken, apiId);
+  const [newApiDef, currentApiDef] = await Promise.all([
+    constructAPIDef(wso2APIM.user, wso2APIM.gatewayEnv, apiDef, apiId),
+    getApiDef(wso2APIM, accessToken, apiId)
+  ]);
+  
+  // ? When no cors configuration is set, it applies the default one from wso2
+  if (!newApiDef.corsConfiguration) return true;
 
   // TODO: We should test for any intersection data between api definition and swagger specs
   return utils.isEqual(newApiDef.corsConfiguration, currentApiDef.corsConfiguration);

--- a/src/3.2.0/wso2apim.js
+++ b/src/3.2.0/wso2apim.js
@@ -797,6 +797,33 @@ async function upsertSwaggerSpec(wso2APIM, accessToken, apiId, swaggerSpec) {
   }
 }
 
+/**
+ * Retrieves the API Definition saved at the WSO2 platform
+ *
+ * @param {*} wso2APIM
+ * @param {string} accessToken
+ * @param {string} apiId
+ * @returns {*}
+ */
+async function getApiDef(wso2APIM, accessToken, apiId) {
+  const url = `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/${apiId}`;
+
+  try {
+    const result = await axios.get(url, {
+      headers: {
+        'Authorization': 'Bearer ' + accessToken
+      },
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: false
+      })
+    });
+
+    return result.data;
+  } catch (err) {
+    utils.renderError(err);
+    throw err;
+  }
+}
 
 module.exports = {
   registerClient,
@@ -818,4 +845,5 @@ module.exports = {
   removeAPIDef,
   listInvokableAPIUrl,
   upsertSwaggerSpec,
+  getApiDef,
 };

--- a/src/3.2.0/wso2apim.js
+++ b/src/3.2.0/wso2apim.js
@@ -825,6 +825,23 @@ async function getApiDef(wso2APIM, accessToken, apiId) {
   }
 }
 
+/**
+ * Check if the API def is up to date
+ *
+ * @param {*} wso2APIM
+ * @param {string} accessToken
+ * @param {string} apiId
+ * @param {Object} apiDef
+ * @returns {Promise<boolean>}
+ */
+async function checkApiDefIsUpdated(wso2APIM, accessToken, apiId, apiDef) {
+  const newApiDef = await constructAPIDef(wso2APIM.user, wso2APIM.gatewayEnv, apiDef, apiId);
+  const currentApiDef = await getApiDef(wso2APIM, accessToken, apiId);
+
+  // TODO: We should test for any intersection data between api definition and swagger specs
+  return utils.isEqual(newApiDef.corsConfiguration, currentApiDef.corsConfiguration);
+}
+
 module.exports = {
   registerClient,
   generateToken,
@@ -846,4 +863,5 @@ module.exports = {
   listInvokableAPIUrl,
   upsertSwaggerSpec,
   getApiDef,
+  checkApiDefIsUpdated,
 };

--- a/src/3.2.0/wso2apim.spec.js
+++ b/src/3.2.0/wso2apim.spec.js
@@ -17,7 +17,8 @@ const {
   upsertSwaggerSpec,
   updateAPIDef,
   removeAPIDef,
-  listInvokableAPIUrl
+  listInvokableAPIUrl,
+  getApiDef,
 } = require('./wso2apim');
 const axios = require('axios');
 const qs = require('qs');
@@ -785,4 +786,25 @@ describe('wso2apim-3.2.0', () => {
     });
   });
 
+  describe('getApiDef()', () => {
+    it('should handle a successful response', async () => {
+      const response = await getApiDef(wso2APIM, 'xxx', 'alias');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        `${publisherBaseUrl}/apis/alias`,
+        {
+          headers: {
+            Authorization: 'Bearer xxx',
+          },
+          httpsAgent: expect.objectContaining({}),
+        }
+      );
+      expect(response).toEqual('foo');
+    });
+
+    it('should handle a faulty response', async () => {
+      axios.get.mockRejectedValueOnce(defaultFaulty);
+      await expect(getApiDef(wso2APIM, 'xxx', 'alias')).rejects.toEqual(defaultFaulty);
+    });
+  });
 });

--- a/src/3.2.0/wso2apim.spec.js
+++ b/src/3.2.0/wso2apim.spec.js
@@ -90,6 +90,18 @@ const wso2APIM = {
 
 const apiId = '123456789';
 
+const baseUrl = `https://${wso2APIM.host}:${wso2APIM.port}`;
+const publisherBaseUrl = `${baseUrl}/api/am/publisher/${wso2APIM.versionSlug}`;
+const storeBaseUrl = `${baseUrl}/api/am/store/${wso2APIM.versionSlug}`;
+
+const defaultFaulty = {
+  response: {
+    data: { message: 'failed' },
+    status: 500,
+    headers: {},
+  },
+};
+
 describe('wso2apim-3.2.0', () => {
 
   describe('registerClient()', () => {
@@ -106,7 +118,7 @@ describe('wso2apim-3.2.0', () => {
       const response = await registerClient(wso2APIM);
 
       expect(axios.post).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/client-registration/v0.17/register`,
+        `${baseUrl}/client-registration/v0.17/register`,
         {
           clientName: 'serverless-wso2-apim',
           owner: wso2APIM.user,
@@ -123,11 +135,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(registerClient(wso2APIM)).rejects.toThrow();
+      await expect(registerClient(wso2APIM)).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -145,7 +155,7 @@ describe('wso2apim-3.2.0', () => {
       const response = await generateToken(wso2APIM, 'foo123', 'xxxyyyzzz');
 
       expect(axios.post).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/oauth2/token`,
+        `${baseUrl}/oauth2/token`,
         qs.stringify({
           'grant_type': 'password',
           'username': wso2APIM.user,
@@ -161,11 +171,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(generateToken(wso2APIM, 'foo123', 'xxxyyyzzz')).rejects.toThrow();
+      await expect(generateToken(wso2APIM, 'foo123', 'xxxyyyzzz')).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -175,7 +183,7 @@ describe('wso2apim-3.2.0', () => {
       const response = await isAPIDeployed(wso2APIM, 'xxx', wso2APIM.apidefs[0].name, wso2APIM.apidefs[0].version, wso2APIM.apidefs[0].rootContext);
 
       expect(axios.get).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis?query=name:${wso2APIM.apidefs[0].name} version:${wso2APIM.apidefs[0].version} context:${wso2APIM.apidefs[0].rootContext}`,
+        `${publisherBaseUrl}/apis?query=name:${wso2APIM.apidefs[0].name} version:${wso2APIM.apidefs[0].version} context:${wso2APIM.apidefs[0].rootContext}`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -187,13 +195,11 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.get.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.get.mockRejectedValueOnce(defaultFaulty);
 
-      expect(
+      await expect(
         isAPIDeployed(wso2APIM, 'xxx', wso2APIM.apidefs[0].name, wso2APIM.apidefs[0].version, wso2APIM.apidefs[0].rootContext)
-      ).rejects.toThrow();
+      ).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -203,7 +209,7 @@ describe('wso2apim-3.2.0', () => {
       const response = await isCertUploaded(wso2APIM, 'xxx', 'alias');
 
       expect(axios.get).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/certificates/alias`,
+        `${publisherBaseUrl}/certificates/alias`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -215,13 +221,11 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.get.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.get.mockRejectedValueOnce(defaultFaulty);
 
-      expect(
+      await expect(
         isCertUploaded(wso2APIM, 'xxx', 'alias')
-      ).rejects.toThrow();
+      ).rejects.toEqual(defaultFaulty);
     });
   });
 
@@ -245,7 +249,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.post).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis?openAPIVersion=V3`,
+        `${publisherBaseUrl}/apis?openAPIVersion=V3`,
         expect.objectContaining({}),
         {
           headers: {
@@ -265,11 +269,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(createAPIDef(wso2APIM, 'xxx', wso2APIM.apidefs[0])).rejects.toThrow();
+      await expect(createAPIDef(wso2APIM, 'xxx', wso2APIM.apidefs[0])).rejects.toBeUndefined();
     });
 
   });
@@ -284,7 +286,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.post).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/change-lifecycle`,
+        `${publisherBaseUrl}/apis/change-lifecycle`,
         expect.objectContaining({}),
         {
           headers: {
@@ -302,11 +304,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(publishAPIDef(wso2APIM, 'xxx', apiId)).rejects.toThrow();
+      await expect(publishAPIDef(wso2APIM, 'xxx', apiId)).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -321,7 +321,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.get).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/store/${wso2APIM.versionSlug}/apis/${apiId}`,
+        `${storeBaseUrl}/apis/${apiId}`,
         {
           headers: {
             Authorization: 'Bearer xxx'
@@ -334,11 +334,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.get.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.get.mockRejectedValueOnce(defaultFaulty);
 
-      expect(listInvokableAPIUrl(wso2APIM, 'xxx', apiId)).rejects.toThrow();
+      await expect(listInvokableAPIUrl(wso2APIM, 'xxx', apiId)).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -358,11 +356,17 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(uploadCert(wso2APIM, 'xxx', 'alias', wso2APIM.apidefs[0].backend.http.certChain, wso2APIM.apidefs[0].backend.http.baseUrl)).rejects.toThrow();
+      await expect(
+        uploadCert(
+          wso2APIM,
+          'xxx',
+          'alias',
+          wso2APIM.apidefs[0].backend.http.certChain,
+          wso2APIM.apidefs[0].backend.http.baseUrl,
+        ),
+      ).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -382,11 +386,18 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.post.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.post.mockRejectedValueOnce(defaultFaulty);
 
-      expect(uploadClientCert(wso2APIM, 'xxx', 'alias', wso2APIM.apidefs[0].backend.http.certChain, wso2APIM.apidefs[0].securityScheme.mutualssl.clientCert,'123')).rejects.toThrow();
+      await expect(
+        uploadClientCert(
+          wso2APIM,
+          'xxx',
+          'alias',
+          wso2APIM.apidefs[0].backend.http.certChain,
+          wso2APIM.apidefs[0].securityScheme.mutualssl.clientCert,
+          '123',
+        ),
+      ).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -403,7 +414,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.put).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/${apiId}`,
+        `${publisherBaseUrl}/apis/${apiId}`,
         expect.objectContaining({}),
         {
           headers: {
@@ -417,11 +428,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.put.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.put.mockRejectedValueOnce(defaultFaulty);
 
-      expect(updateAPIDef(wso2APIM, 'xxx', wso2APIM.apidefs[0], apiId)).rejects.toThrow();
+      await expect(updateAPIDef(wso2APIM, 'xxx', wso2APIM.apidefs[0], apiId)).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -436,7 +445,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.delete).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/${apiId}`,
+        `${publisherBaseUrl}/apis/${apiId}`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -447,11 +456,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.delete.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.delete.mockRejectedValueOnce(defaultFaulty);
 
-      expect(removeAPIDef(wso2APIM, 'xxx', apiId)).rejects.toThrow();
+      await expect(removeAPIDef(wso2APIM, 'xxx', apiId)).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -466,7 +473,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.delete).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/certificates/alias`,
+        `${publisherBaseUrl}/certificates/alias`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -477,11 +484,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.delete.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.delete.mockRejectedValueOnce(defaultFaulty);
 
-      expect(removeCert(wso2APIM, 'xxx', 'alias')).rejects.toThrow();
+      await expect(removeCert(wso2APIM, 'xxx', 'alias')).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -497,7 +502,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.delete).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/123/client-certificates/alias`,
+        `${publisherBaseUrl}/apis/123/client-certificates/alias`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -508,11 +513,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.delete.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.delete.mockRejectedValueOnce(defaultFaulty);
 
-      expect(removeClientCert(wso2APIM, 'xxx', 'alias', '123')).rejects.toThrow();
+      await expect(removeClientCert(wso2APIM, 'xxx', 'alias', '123')).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -529,7 +532,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.put).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/endpoint-certificates/alias`,
+        `${publisherBaseUrl}/endpoint-certificates/alias`,
         expect.objectContaining({}),
         {
           headers: {
@@ -543,11 +546,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.put.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.put.mockRejectedValueOnce(defaultFaulty);
 
-      expect(updateCert(wso2APIM, 'xxx', 'alias', wso2APIM.apidefs[0].backend.http.certChain)).rejects.toThrow();
+      await expect(updateCert(wso2APIM, 'xxx', 'alias', wso2APIM.apidefs[0].backend.http.certChain)).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -565,7 +566,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.put).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/123/client-certificates/alias`,
+        `${publisherBaseUrl}/apis/123/client-certificates/alias`,
         expect.objectContaining({}),
         {
           headers: {
@@ -579,11 +580,17 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.put.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.put.mockRejectedValueOnce(defaultFaulty);
 
-      expect(updateClientCert(wso2APIM, 'xxx', 'alias', wso2APIM.apidefs[0].securityScheme.mutualssl.clientCert, '123')).rejects.toThrow();
+      await expect(
+        updateClientCert(
+          wso2APIM,
+          'xxx',
+          'alias',
+          wso2APIM.apidefs[0].securityScheme.mutualssl.clientCert,
+          '123',
+        ),
+      ).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -598,7 +605,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.get).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/certificates/alias`,
+        `${publisherBaseUrl}/certificates/alias`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -612,11 +619,9 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.get.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.get.mockRejectedValueOnce(defaultFaulty);
 
-      expect(listCertInfo(wso2APIM, 'xxx', 'alias')).rejects.toThrow();
+      await expect(listCertInfo(wso2APIM, 'xxx', 'alias')).rejects.toEqual(defaultFaulty);
     });
 
   });
@@ -632,7 +637,7 @@ describe('wso2apim-3.2.0', () => {
       );
 
       expect(axios.get).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/123/client-certificates/alias`,
+        `${publisherBaseUrl}/apis/123/client-certificates/alias`,
         {
           headers: {
             Authorization: 'Bearer xxx',
@@ -646,21 +651,19 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.get.mockImplementationOnce(() =>
-        Promise.reject()
-      );
+      axios.get.mockRejectedValueOnce(defaultFaulty);
 
-      expect(listClientCertInfo(wso2APIM, 'xxx', 'alias', '123')).rejects.toThrow();
+      await expect(listClientCertInfo(wso2APIM, 'xxx', 'alias', '123')).rejects.toEqual(defaultFaulty);
     });
 
   });
 
   describe('upsertSwaggerSpec()', () => {
     it('should handle a successful response', async () => {
-      const response = await upsertSwaggerSpec(wso2APIM, 'xxx', 'id001', wso2APIM.apidefs[0].swaggerSpec);
+      await upsertSwaggerSpec(wso2APIM, 'xxx', 'id001', wso2APIM.apidefs[0].swaggerSpec);
 
       expect(axios.put).toHaveBeenCalledWith(
-        `https://${wso2APIM.host}:${wso2APIM.port}/api/am/publisher/${wso2APIM.versionSlug}/apis/id001/swagger`,
+        `${publisherBaseUrl}/apis/id001/swagger`,
         expect.objectContaining({}),
         {
           headers: {
@@ -673,8 +676,8 @@ describe('wso2apim-3.2.0', () => {
     });
 
     it('should handle a faulty response', async () => {
-      axios.put.mockImplementationOnce(() => Promise.reject());
-      expect(upsertSwaggerSpec(wso2APIM, 'xxx', 'id001', wso2APIM.apidefs[0].swaggerSpec)).rejects.toThrow();
+      axios.put.mockRejectedValueOnce(defaultFaulty);
+      await expect(upsertSwaggerSpec(wso2APIM, 'xxx', 'id001', wso2APIM.apidefs[0].swaggerSpec)).rejects.toEqual(defaultFaulty);
     });
   });
 

--- a/src/3.2.0/wso2apim.spec.js
+++ b/src/3.2.0/wso2apim.spec.js
@@ -880,5 +880,10 @@ describe('wso2apim-3.2.0', () => {
       const response = await checkApiDefIsUpdated(wso2APIM, 'xxx', 'alias', config.apidefs[0]);
       expect(response).toBeFalsy();
     });
+
+    it('should return truthy when the there is no cors configuration', async () => {
+      const response = await checkApiDefIsUpdated(wso2APIM, 'xxx', 'alias', wso2APIM.apidefs[0]);
+      expect(response).toBeTruthy();
+    });
   });
 });

--- a/src/3.2.0/wso2apim.spec.js
+++ b/src/3.2.0/wso2apim.spec.js
@@ -839,13 +839,7 @@ describe('wso2apim-3.2.0', () => {
         {
           ...wso2APIM.apidefs[0],
           cors: {
-            headers: [
-              'Authorization',
-              'Access-Control-Allow-Origin',
-              'Content-Type',
-              'SOAPAction',
-              'x-custom-header',
-            ],
+            headers: corsConfiguration.accessControlAllowHeaders,
           },
         },
       ],

--- a/src/index.js
+++ b/src/index.js
@@ -851,6 +851,7 @@ class Serverless_WSO2_APIM {
       // Create API definitions, if they do not exist
       // Update API definitions, if they exist
       for (const [i, api] of this.cache.deploymentStatus.entries()) {
+        // ? seconds sleeping on each retry: 2, 4, 8, 16, 32, 64
         await retryWithExponentialBackoff(({ attempt }) => deployApiDefAndUpsertSwagger(wso2APIM, api, apiDefs[i], attempt), {
           intervalSeconds: 2,
           maxAttempts: 6,

--- a/src/utils/retryWithExponentialBackoff.js
+++ b/src/utils/retryWithExponentialBackoff.js
@@ -52,10 +52,10 @@ const validateConfig = ({ intervalSeconds, maxAttempts, backoffRate }) => {
  * }
  * 
  * async function main() {
- *   const simpleRetry = retryWithExponentialBackoff(() => getFooById(1));
+ *   const simpleRetry = retryWithExponentialBackoff(() => getFooById('uuid'));
  *   
  *   const retryWithParams = retryWithExponentialBackoff(
- *     () => getFooById(1),
+ *     () => getFooById('uuid'),
  *     {
  *       intervalSeconds: 2,
  *       maxAttempts: 5,
@@ -64,11 +64,11 @@ const validateConfig = ({ intervalSeconds, maxAttempts, backoffRate }) => {
  *   );
  * 
  *   const retryReceivingAttempts = retryWithExponentialBackoff(({ attempt }) => {
- *     if (attempt > 1) {
- *       logger.addLog('failed to fetch foo');
+ *     if (attempt === 3) {
+ *       return getFooById('fallback-foo-id');
  *     }
  * 
- *     return getFooById(1);
+ *     return getFooById('uuid');
  *   });
  * }
  */
@@ -86,7 +86,7 @@ async function retryWithExponentialBackoff(fn, configParams) {
   const execute = async () => {
     try {
       return await fn({
-        // ? attempt starts with 0 internally, but we want to expose it starting with 1 for better understanding.
+        // ? attempt starts with 0 internally, but we want to expose it starting with 1 for natural language purpose.
         attempt: attempt + 1
       });
     } catch (error) {

--- a/src/utils/retryWithExponentialBackoff.js
+++ b/src/utils/retryWithExponentialBackoff.js
@@ -1,0 +1,83 @@
+const { goToSleep } = require('./utils');
+
+/**
+ * The retry with exponential backoff config
+ * @typedef {Object} Config
+ * @property {undefined|number} intervalSeconds A positive integer that represents the number of seconds before the first retry attempt (1 by default).
+ * @property {undefined|number} maxAttempts A positive integer that represents the maximum number of retry attempts (3 by default).
+ * @property {undefined|number} backoffRate The multiplier by which the retry interval denoted by IntervalSeconds increases after each retry attempt (2.0 by default).
+ */
+
+/**
+ * Add the default values to the config
+ * @param {Config} config 
+ * @returns {Config}
+ */
+const normalizeConfig = (config) => ({
+  intervalSeconds: 1,
+  maxAttempts: 3,
+  backoffRate: 2,
+  ...config,
+});
+
+/**
+ * Validates the config object
+ * @param {Config} config 
+ */
+const validateConfig = ({ intervalSeconds, maxAttempts, backoffRate }) => {
+  if (typeof intervalSeconds !== 'number' || intervalSeconds <= 0) {
+    throw new Error('retryWithExponentialBackoff: config.intervalSeconds must be a number greater than 0');
+  }
+
+  if (typeof maxAttempts !== 'number' || maxAttempts <= 0) {
+    throw new Error('retryWithExponentialBackoff: config.maxAttempts must be a number greater than 0');
+  }
+
+  if (typeof backoffRate !== 'number' || backoffRate <= 0) {
+    throw new Error('retryWithExponentialBackoff: config.backoffRate must be a number greater than 0');
+  }
+};
+
+/**
+ * Execute a promise and retry with exponential backoff
+ * based on the maximum retry attempts it can perform
+ * @param {<T>(...params: unknown[]) => Promise<T>} fn function to be executed
+ * @param {Config} configParams retry config
+ * @returns Promise<T>
+ */
+async function retryWithExponentialBackoff(fn, configParams) {
+  if (typeof fn !== 'function') {
+    throw new Error('retryWithExponentialBackoff: fn must be a function to be retried');
+  }
+
+  const { backoffRate, intervalSeconds, maxAttempts } = normalizeConfig(configParams);
+  validateConfig({ backoffRate, intervalSeconds, maxAttempts });
+
+  let attempt = 0;
+  const intervalMs = intervalSeconds * 1000;
+
+  const execute = async () => {
+    try {
+      return await fn();
+    } catch (error) {
+      const delayMs = intervalMs * (backoffRate ** attempt);
+      await goToSleep(delayMs);
+
+      attempt++;
+
+      if (attempt === maxAttempts) {
+        throw error;
+      }
+
+      return execute();
+    }
+  };
+
+  return execute();
+}
+
+module.exports = {
+  validateConfig,
+  normalizeConfig,
+  retryWithExponentialBackoff,
+};

--- a/src/utils/retryWithExponentialBackoff.spec.js
+++ b/src/utils/retryWithExponentialBackoff.spec.js
@@ -1,0 +1,165 @@
+const { retryWithExponentialBackoff, validateConfig, normalizeConfig } = require('./retryWithExponentialBackoff');
+
+describe('retryWithExponentialBackoff', () => {
+  describe('normalizeConfig', () => {
+    it('should return default config if no config provided', () => {
+      const result = normalizeConfig();
+      expect(result).toEqual({
+        intervalSeconds: 1,
+        maxAttempts: 3,
+        backoffRate: 2,
+      });
+    });
+
+    it('should override default values with provided values', () => {
+      const result = normalizeConfig({
+        intervalSeconds: 5,
+        maxAttempts: 10,
+        backoffRate: 3,
+      });
+      expect(result).toEqual({
+        intervalSeconds: 5,
+        maxAttempts: 10,
+        backoffRate: 3,
+      });
+    });
+
+    it('should merge the default values with provided values', () => {
+      const result = normalizeConfig({
+        backoffRate: 2.5,
+      });
+      expect(result).toEqual({
+        intervalSeconds: 1,
+        maxAttempts: 3,
+        backoffRate: 2.5,
+      });
+    });
+  });
+
+  describe('validateConfig', () => {
+    const intervalSecondsError = new Error('retryWithExponentialBackoff: config.intervalSeconds must be a number greater than 0');
+    const maxAttemptsError = new Error('retryWithExponentialBackoff: config.maxAttempts must be a number greater than 0');
+    const backoffRateError = new Error('retryWithExponentialBackoff: config.backoffRate must be a number greater than 0');
+
+    it('should pass the default config', () => {
+      expect(() => validateConfig(normalizeConfig())).not.toThrow();
+    });
+
+    it('should pass the provided config', () => {
+      expect(() => validateConfig({
+        intervalSeconds: 1,
+        maxAttempts: 10,
+        backoffRate: 5,
+      })).not.toThrow();
+    });
+
+    it.each([
+      {
+        caseName: 'invalid intervalSeconds',
+        config: normalizeConfig({ intervalSeconds: 'invalid' }),
+        error: intervalSecondsError,
+      },
+      {
+        caseName: 'zero intervalSeconds',
+        config: normalizeConfig({ intervalSeconds: 0 }),
+        error: intervalSecondsError,
+      },
+      {
+        caseName: 'negative intervalSeconds',
+        config: normalizeConfig({ intervalSeconds: -10 }),
+        error: intervalSecondsError,
+      },
+      {
+        caseName: 'invalid maxAttempts',
+        config: normalizeConfig({ maxAttempts: 'invalid' }),
+        error: maxAttemptsError,
+      },
+      {
+        caseName: 'zero maxAttempts',
+        config: normalizeConfig({ maxAttempts: 0 }),
+        error: maxAttemptsError,
+      },
+      {
+        caseName: 'negative maxAttempts',
+        config: normalizeConfig({ maxAttempts: -10 }),
+        error: maxAttemptsError,
+      },
+      {
+        caseName: 'invalid backoffRate',
+        config: normalizeConfig({ backoffRate: 'invalid' }),
+        error: backoffRateError,
+      },
+      {
+        caseName: 'zero backoffRate',
+        config: normalizeConfig({ backoffRate: 0 }),
+        error: backoffRateError,
+      },
+      {
+        caseName: 'negative backoffRate',
+        config: normalizeConfig({ backoffRate: -10 }),
+        error: backoffRateError,
+      },
+    ])('should throw an error for $caseName', ({ config, error }) => {
+      expect(() => validateConfig(config)).toThrow(error);
+    });
+  });
+
+  describe('retryWithExponentialBackoff', () => {
+    const fnError = new Error('retryWithExponentialBackoff: fn must be a function to be retried');
+
+    it('should retry and succeed after a certain number of attempts', async () => {
+      const mockFunction = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Simulated error'))
+        .mockResolvedValueOnce('Success');
+
+      const result = await retryWithExponentialBackoff(mockFunction);
+
+      expect(result).toBe('Success');
+      expect(mockFunction).toHaveBeenCalledTimes(2); // 1 initial attempt + 1 retry
+    });
+
+    it('should throw an error after reaching maxAttempts', async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error('Simulated error'));
+
+      await expect(
+        retryWithExponentialBackoff(mockFunction, {
+          maxAttempts: 2,
+        })
+      ).rejects.toThrow('Simulated error');
+
+      expect(mockFunction).toHaveBeenCalledTimes(2); // 1 initial attempt + 1 retry
+    });
+
+    it('should not retry when succeed in the first call', async () => {
+      const mockFunction = jest.fn().mockResolvedValue('Success');
+
+      const result = await retryWithExponentialBackoff(mockFunction);
+
+      expect(result).toBe('Success');
+      expect(mockFunction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be able to execute an async function', async () => {
+      const testFn = async (input) => input;
+
+      const result = await retryWithExponentialBackoff(() => testFn('Success'));
+      expect(result).toBe('Success');
+    });
+
+    it('should be able to execute a sync function', async () => {
+      const testFn = (input) => input;
+
+      const result = await retryWithExponentialBackoff(() => testFn('Success'));
+      expect(result).toBe('Success');
+    });
+
+    it('should throw error if fn is not a function', async () => {
+      await expect(retryWithExponentialBackoff('function')).rejects.toEqual(fnError);
+    });
+
+    it('should throw error if fn is a promise', async () => {
+      await expect(retryWithExponentialBackoff('function')).rejects.toEqual(fnError);
+    });
+  });
+});

--- a/src/utils/retryWithExponentialBackoff.spec.js
+++ b/src/utils/retryWithExponentialBackoff.spec.js
@@ -171,10 +171,8 @@ describe('retryWithExponentialBackoff', () => {
     });
 
     it('should throw error if fn is a promise', async () => {
-      const fn = async () => 'test';
-      const promiseFnCall = fn();
-
-      await expect(retryWithExponentialBackoff(promiseFnCall)).rejects.toEqual(fnError);
+      const testFn = async () => 'test';
+      await expect(retryWithExponentialBackoff(testFn())).rejects.toEqual(fnError);
     });
   });
 });

--- a/src/utils/retryWithExponentialBackoff.spec.js
+++ b/src/utils/retryWithExponentialBackoff.spec.js
@@ -140,6 +140,18 @@ describe('retryWithExponentialBackoff', () => {
       expect(mockFunction).toHaveBeenCalledTimes(1);
     });
 
+    it('should provide the attempt number to the caller function', async () => {
+      const mockFunction = jest.fn().mockRejectedValue(new Error('Simulated error'));
+
+      await expect(
+        retryWithExponentialBackoff(mockFunction, { backoffRate: 0.01 })
+      ).rejects.toThrow('Simulated error');
+
+      expect(mockFunction).toHaveBeenNthCalledWith(1, { attempt: 1 });
+      expect(mockFunction).toHaveBeenNthCalledWith(2, { attempt: 2 });
+      expect(mockFunction).toHaveBeenNthCalledWith(3, { attempt: 3 });
+    });
+
     it('should be able to execute an async function', async () => {
       const testFn = async (input) => input;
 
@@ -159,7 +171,10 @@ describe('retryWithExponentialBackoff', () => {
     });
 
     it('should throw error if fn is a promise', async () => {
-      await expect(retryWithExponentialBackoff('function')).rejects.toEqual(fnError);
+      const fn = async () => 'test';
+      const promiseFnCall = fn();
+
+      await expect(retryWithExponentialBackoff(promiseFnCall)).rejects.toEqual(fnError);
     });
   });
 });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -35,10 +35,14 @@ function resolveCfImportValue(provider, name, params = {}) {
     return null;
   });
 }
-  
+
+function isEqual(object1, object2) {
+  return JSON.stringify(object1) === JSON.stringify(object2);
+}
 
 module.exports = {
   renderError,
   goToSleep,
   resolveCfImportValue,
+  isEqual,
 };

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -1,4 +1,4 @@
-const { resolveCfImportValue } = require('./utils');
+const { resolveCfImportValue, isEqual } = require('./utils');
 
 describe('resolveCfImportValue', () => {
   let calls = 0;
@@ -49,5 +49,27 @@ describe('resolveCfImportValue', () => {
 
     expect(val).toEqual('C');
     expect(calls).toEqual(2);
+  });
+});
+
+describe('isEqual', () => {
+  const baseObject = {
+    number: 1234,
+    text: 'text',
+    bool: true,
+    array: ['1234', {}, null, undefined]
+  };
+
+  it('should return truthy to equal objects', () => {
+    expect(isEqual(baseObject, baseObject)).toBeTruthy();
+  });
+
+  it('should return falsy to non equal objects', () => {
+    const newObject = {
+      ...baseObject,
+      array: ['1234'],
+    };
+
+    expect(isEqual(baseObject, newObject)).toBeFalsy();
   });
 });


### PR DESCRIPTION
# Description

This is a follow-up of the discussion from pull request #114
It also fixes the #99 

---

## Issue
In some complex/distributed WSO2 setups it may take a while to synchronize the API definitions. When upserting the swagger right after the API def update, it will override the common data between them (e.g., CORS Headers) with the outdated API definitions.

## Proposal

Creates an exponential backoff retry to keep retrying to update the WSO2 API definitions while it differs from what we expect.
it starts executing without delay, as it fails, we start sleeping for 2 seconds, then 4s, 8s, 16s, 32s, and finally 64 seconds.


## Checklist
- [x] Updated unit tests (`*.spec.js`)  
- [ ] Updated e2e tests ([here](https://github.com/ramgrandhi/serverless-wso2-apim/tree/main/src/__tests__/e2e))  
- [ ] Updated documentation ([here](https://github.com/ramgrandhi/serverless-wso2-apim/blob/main/README.md))   
